### PR TITLE
Ensure compatibility with Node < 4.x.

### DIFF
--- a/services/has-many-getter.js
+++ b/services/has-many-getter.js
@@ -58,7 +58,7 @@ function HasManyGetter(model, association, opts, params) {
           descending = true;
         }
 
-        let recordsSorted = _.sortBy(records, function(record) {
+        var recordsSorted = _.sortBy(records, function(record) {
           return record[fieldSort];
         });
 

--- a/services/operator-value-parser.js
+++ b/services/operator-value-parser.js
@@ -58,7 +58,7 @@ function OperatorValueParser(opts) {
       var from = null;
       var to = null;
 
-      let match = value.match(/^last(\d+)days$/);
+      var match = value.match(/^last(\d+)days$/);
       if (match && match[1]) {
         return { $gte: moment().subtract(match[1], 'days').toDate() };
       }


### PR DESCRIPTION
Hi,
We would like to use ForestAdmin with node v0.10.32. 
Node doesn't support 'let' before 4.x.
Thanks