### PR TITLE
Added : excludedModels & includedModels options to filter models published to ForestAdmin

### DIFF
--- a/adapters/mongoose.js
+++ b/adapters/mongoose.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var flat = require('flat');
 var utils = require('../utils/schema');
 var Interface = require('forest-express');
+var mongooseUtils = require('../services/mongoose-utils');
 
 module.exports = function (model, opts) {
   var fields = [];
@@ -14,8 +15,9 @@ module.exports = function (model, opts) {
   var schemaType;
 
   function formatRef(ref) {
-    if (opts.mongoose.models[ref]) {
-      return utils.getModelName(opts.mongoose.models[ref]);
+    var models = mongooseUtils.getModels(opts);
+    if (models[ref]) {
+      return utils.getModelName(models[ref]);
     } else {
       Interface.logger.warn('Cannot find the reference \"' + ref +
         '\" on the model \"' + model.modelName + '\".');

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var P = require('bluebird');
 var Interface = require('forest-express');
 var utils = require('./utils/schema');
+var mongooseUtils = require('./services/mongoose-utils');
 
 exports.collection = Interface.collection;
 exports.ensureAuthenticated = Interface.ensureAuthenticated;
@@ -22,7 +23,7 @@ exports.init = function(opts) {
   exports.SchemaAdapter = require('./adapters/mongoose');
 
   exports.getModels = function () {
-    return opts.mongoose.models;
+    return mongooseUtils.getModels(opts);
   };
 
   exports.getModelName = utils.getModelName;

--- a/services/mongoose-utils.js
+++ b/services/mongoose-utils.js
@@ -19,15 +19,18 @@ module.exports = {
     }
     // Initially opts.mongoose.models is indexed by modelName
     // so we filter (which gives us an array)
-    // then we re-index by modelName)
-    return _.chain(opts.mongoose.models)
-      .filter(function (model, modelName) {
-        if (!_.isEmpty(opts.includedModels)) {
-          return _.includes(opts.includedModels, modelName);
-        } else {
-          return !_.includes(opts.excludedModels, modelName);
-        }
-      })
+    // then we re-index by modelName
+    var models = _.chain(opts.mongoose.models);
+    if (!_.isEmpty(opts.includedModels)) {
+      models = models.filter(function (model, modelName) {
+        return _.includes(opts.includedModels, modelName);
+      });
+    } else {
+      models = models.filter(function (model, modelName) {
+        return !_.includes(opts.excludedModels, modelName);
+      });
+    }
+    return models
       .indexBy('modelName')
       .value();
   }

--- a/services/mongoose-utils.js
+++ b/services/mongoose-utils.js
@@ -11,5 +11,24 @@ module.exports = {
         return opts.options.type[0].ref;
       }
     }
+  },
+  getModels : function(opts) {
+    // Return normal list when options don't contradict it
+    if (_.isEmpty(opts.includedModels) && _.isEmpty(opts.excludedModels)) {
+      return opts.mongoose.models;
+    }
+    // Initially opts.mongoose.models is indexed by modelName
+    // so we filter (which gives us an array)
+    // then we re-index by modelName)
+    return _.chain(opts.mongoose.models)
+      .filter(function (model, modelName) {
+        if (!_.isEmpty(opts.includedModels)) {
+          return _.includes(opts.includedModels, modelName);
+        } else {
+          return !_.includes(opts.excludedModels, modelName);
+        }
+      })
+      .indexBy('modelName')
+      .value();
   }
 };

--- a/services/resources-getter.js
+++ b/services/resources-getter.js
@@ -5,6 +5,7 @@ var OperatorValueParser = require('./operator-value-parser');
 var FilterParser = require('./filter-parser');
 var Interface = require('forest-express');
 var utils = require('../utils/schema');
+var mongooseUtils = require('./mongoose-utils');
 
 function ResourcesGetter(model, opts, params) {
   var schema = Interface.Schemas.schemas[utils.getModelName(model)];
@@ -95,7 +96,7 @@ function ResourcesGetter(model, opts, params) {
           var currentField = _.findWhere(schema.fields, { field: fieldName });
           if (currentField && currentField.reference) {
             // NOTICE: Look for the associated model infos
-            var subModel = _.find(opts.mongoose.models, function(model) {
+            var subModel = _.find(mongooseUtils.getModels(opts), function(model) {
               return model.collection.name ===
                 currentField.reference.split('.')[0];
             });


### PR DESCRIPTION
In our case, we use mongoose models for several things (real model writing, model validation, and schema description for swagger).
Some registered models need therefore to stay away from ForestAdmin and with this pull request, I simply allow `opts` to contain an optional `getModels` function where it's left to the user to return the list of the mongoose models. In my case I use lodash to filter `opts.mongoose.models` based on some business logic.

This keeps ForestAdmin clean and avoids having to jump to ForestAdmin quickly upon delivery to make sure we hide models which are not supposed to show in the first place.