### PR TITLE
Fix mongoose array with enums

### DIFF
--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -143,9 +143,7 @@ module.exports = function (model, opts) {
           return [schemaType(opts.options.type[0])];
         } else {
           // Object
-          return [objectType(opts.options.type[0], function (key) {
-            return getTypeFromNative(opts.options.type[0][key]);
-          })];
+          return [getTypeFromNative(opts.options.type[0])];
         }
       }
     } else if (opts.enumValues && opts.enumValues.length) {


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [ ] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code

Hi guys, I was having a problem with this mongoose schema definition:

```js
new Schema({
  permissions: [{
    type: String,
    enum: [
      "user:read",
      "user:write"
    ],
  }]
}
```

It was generating this in the `.forestadmin-schema.json` and it was breaking:

```js
{
  "field": "permissions",
  "type": [{
    "fields": [{
      "field": "type",
      "type": "String"
    }, {
      "field": "enum",
      "type": [null]
    }]
  }],
  "defaultValue": null,
  "enums": null,
  "integration": null,
  "isFilterable": true,
  "isReadOnly": false,
  "isRequired": false,
  "isSortable": true,
  "isVirtual": false,
  "reference": null,
  "inverseOf": null,
  "validations": []
}

```

The modification that I've made generates this:

```js
{
  "field": "permissions",
  "type": ["Enum"],
  "defaultValue": null,
  "enums": null,
  "integration": null,
  "isFilterable": true,
  "isReadOnly": false,
  "isRequired": false,
  "isSortable": true,
  "isVirtual": false,
  "reference": null,
  "inverseOf": null,
  "validations": []
}
```

It is still missing the "enums" and I don't believe forest admin supports this at least for now but does not break!