### PR TITLE
[+] Schema - Detect enum values for Enums in array schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Readme - Add a badge for the NPM package version.
+- Schema - Add detection of enum values for Enums in array schema
 
 ### Changed
 - Readme - Add a community section.

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -178,8 +178,17 @@ module.exports = function (model, opts) {
 
   schemaType = function (type) {
     return {
-      fields: _.map(type.paths, function (type, field) {
-        return { field: field, type: getTypeFromMongoose(type) };
+      fields: _.map(type.paths, function (type, fieldName) {
+        const field = {
+          field: fieldName,
+          type: getTypeFromMongoose(type)
+        };
+
+        if (type.enumValues && type.enumValues.length) {
+          field.enums = type.enumValues;
+        }
+
+        return field;
       })
     };
   };


### PR DESCRIPTION
According to https://mongoosejs.com/docs/subdocs.html#altsyntax
a schema for an array of objects can be declared as a mongoose
schema instance or a plain object.

The type is generated using schemaType when it is a mongoose
schema instance, else objectType is used.

This commit adds the detection of enum values to schemaType
as this was only supported in objectType (when the schema
is defined as a plain object).

Signed-off-by: Chris Lahaye <dev@chrislahaye.com>

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
