### PR TITLE
[+] Search - Do not return fields that are hidden from the UI except if a smart field is displayed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Changed
-- Search - In a request with no smart fields, do not return fields that are hidden from the UI.
+- Performance optimization - In a request with no smart fields, do not return fields that are hidden from the UI.
 
 ### Fixed
 - Technical - Exclude from pre-commit-hook linter files that are not committed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Search - In a request with no smart fields, do not return fields that are hidden from the UI.
+
 ### Changed
 - Technical - Jest node configuration.
 - Technical - Rename `.env.example` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [Unreleased]
-### Added
+### Changed
 - Search - In a request with no smart fields, do not return fields that are hidden from the UI.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Changed
+- Technical - Jest node configuration.
 - Technical - Rename `.env.example` file.
 - Technical - Upgrade ESLint rules.
 - Technical - Ensure that all files follow the ESLint rules.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/src/services/projection-builder.js
+++ b/src/services/projection-builder.js
@@ -21,7 +21,7 @@ class ProjectionBuilder {
   findRequestSmartField(requestFieldsNames) {
     if (this.schemaSmartFields && requestFieldsNames) {
       return this.schemaSmartFields
-        .filter((fieldName) => requestFieldsNames.indexOf(fieldName) > -1);
+        .filter((fieldName) => requestFieldsNames.includes(fieldName));
     }
     return [];
   }

--- a/src/services/projection-builder.js
+++ b/src/services/projection-builder.js
@@ -2,7 +2,7 @@ class ProjectionBuilder {
   constructor(schema) {
     this.schemaSmartFields = schema
       && schema.fields
-      && schema.fields.filter(field => field.get).map(field => field.field);
+      && schema.fields.filter((field) => field.get).map((field) => field.field);
   }
 
   // NOTICE: Convert a list of field names into a mongo $project structure

--- a/src/services/projection-builder.js
+++ b/src/services/projection-builder.js
@@ -5,7 +5,7 @@ class ProjectionBuilder {
       && schema.fields.filter((field) => field.get).map((field) => field.field);
   }
 
-  // NOTICE: Convert a list of field names into a mongo $project structure
+  // NOTICE: Convert a list of field names into a mongo $project structure.
   static convertToProjection(fieldsNames) {
     if (fieldsNames) {
       const fieldsObject = fieldsNames.reduce((fields, fieldName) => {

--- a/src/services/projection-builder.js
+++ b/src/services/projection-builder.js
@@ -1,0 +1,36 @@
+class ProjectionBuilder {
+  constructor(schema) {
+    this.schemaSmartFields = schema
+      && schema.fields
+      && schema.fields.filter(field => field.get).map(field => field.field);
+  }
+
+  // NOTICE: Convert a list of field names into a mongo $project structure
+  static convertToProjection(fieldsNames) {
+    if (fieldsNames) {
+      const fieldsObject = fieldsNames.reduce((fields, fieldName) => {
+        fields[fieldName] = 1;
+        return fields;
+      }, {});
+      return { $project: fieldsObject };
+    }
+    return null;
+  }
+
+  // NOTICE: Perform the intersection between schema and request smart fields.
+  findRequestSmartField(requestFieldsNames) {
+    if (this.schemaSmartFields && requestFieldsNames) {
+      return this.schemaSmartFields
+        .filter((fieldName) => requestFieldsNames.indexOf(fieldName) > -1);
+    }
+    return [];
+  }
+
+  getProjection(fieldNames) {
+    const requestSmartFields = this.findRequestSmartField(fieldNames);
+    if (requestSmartFields.length) return null;
+    return ProjectionBuilder.convertToProjection(fieldNames);
+  }
+}
+
+module.exports = ProjectionBuilder;

--- a/src/services/query-builder.js
+++ b/src/services/query-builder.js
@@ -4,11 +4,13 @@ import utils from '../utils/schema';
 import Orm from '../utils/orm';
 import SearchBuilder from './search-builder';
 import FiltersParser from './filters-parser';
+import ProjectionBuilder from './projection-builder';
 
 function QueryBuilder(model, params, opts) {
   const schema = Interface.Schemas.schemas[utils.getModelName(model)];
   const searchBuilder = new SearchBuilder(model, opts, params, schema.searchFields);
   const filterParser = new FiltersParser(model, params.timezone, opts);
+  const projectionBuilder = new ProjectionBuilder(schema);
 
   const { filters } = params;
 
@@ -34,6 +36,10 @@ function QueryBuilder(model, params, opts) {
       associations,
     );
   };
+
+  this.addProjection = (jsonQuery) => this.getFieldNamesRequested()
+    .then(fieldNames => projectionBuilder.getProjection(fieldNames))
+    .then(projection => projection && jsonQuery.push(projection));
 
   this.addJoinToQuery = (field, joinQuery) => {
     if (field.reference && !field.isVirtual && !field.integration) {
@@ -128,6 +134,11 @@ function QueryBuilder(model, params, opts) {
 
   this.getQueryWithFiltersAndJoins = async (segment) => {
     const jsonQuery = [];
+    await this.addFiltersAndJoins(jsonQuery, segment);
+    return jsonQuery;
+  };
+
+  this.addFiltersAndJoins = async (jsonQuery, segment) => {
     const conditions = [];
 
     if (filters) {
@@ -150,7 +161,7 @@ function QueryBuilder(model, params, opts) {
       });
     }
 
-    return jsonQuery;
+    return this;
   };
 }
 

--- a/src/services/query-builder.js
+++ b/src/services/query-builder.js
@@ -38,8 +38,8 @@ function QueryBuilder(model, params, opts) {
   };
 
   this.addProjection = (jsonQuery) => this.getFieldNamesRequested()
-    .then(fieldNames => projectionBuilder.getProjection(fieldNames))
-    .then(projection => projection && jsonQuery.push(projection));
+    .then((fieldNames) => projectionBuilder.getProjection(fieldNames))
+    .then((projection) => projection && jsonQuery.push(projection));
 
   this.addJoinToQuery = (field, joinQuery) => {
     if (field.reference && !field.isVirtual && !field.integration) {

--- a/src/services/resources-getter.js
+++ b/src/services/resources-getter.js
@@ -27,7 +27,9 @@ function ResourcesGetter(model, opts, params) {
 
   this.perform = () => getSegmentCondition()
     .then(async (segment) => {
-      const jsonQuery = await queryBuilder.getQueryWithFiltersAndJoins(segment);
+      const jsonQuery = [];
+      await queryBuilder.addProjection(jsonQuery);
+      await queryBuilder.addFiltersAndJoins(jsonQuery, segment);
 
       if (params.search) {
         fieldsSearched = queryBuilder.getFieldsSearched();

--- a/test/tests/services/projection-builder.test.js
+++ b/test/tests/services/projection-builder.test.js
@@ -1,0 +1,105 @@
+import ProjectionBuilder from '../../../src/services/projection-builder';
+
+describe('service > projection-builder', () => {
+  describe('findRequestSmartField', () => {
+    it('should return the intersect between request fields and schema fields', () => {
+      expect.assertions(1);
+
+      const schemaWithSmartFields = {
+        fields: [
+          {
+            field: 'firstname',
+            type: 'String',
+          },
+          {
+            field: 'lastname',
+            type: 'String',
+          },
+          {
+            field: 'fullname',
+            type: 'String',
+            get: (doc) => `${doc.firstname} ${doc.lastname}`,
+          },
+          {
+            field: 'otherSmartField',
+            type: 'String',
+            get: (doc) => `${doc.firstname} ${doc.lastname}`,
+          },
+        ],
+      };
+      const projectionBuilder = new ProjectionBuilder(schemaWithSmartFields);
+      const requestFields = ['fullname', 'firstname'];
+      const expectedRequestSmartFields = ['fullname'];
+      const actualRequestSmartFields = projectionBuilder.findRequestSmartField(requestFields);
+      expect(actualRequestSmartFields).toStrictEqual(expectedRequestSmartFields);
+    });
+  });
+  describe('convertToProjection', () => {
+    it('should return a valid projection', () => {
+      expect.assertions(1);
+
+      const expectedProjection = { $project: { one: 1, two: 1 } };
+      const actualProjection = ProjectionBuilder.convertToProjection(['one', 'two']);
+
+      expect(actualProjection).toStrictEqual(expectedProjection);
+    });
+  });
+
+  describe('getProjection without requested smart fields', () => {
+    it('should returns a valid projection', () => {
+      expect.assertions(1);
+
+      const schemaWithSmartFields = {
+        fields: [
+          {
+            field: 'firstname',
+            type: 'String',
+          },
+          {
+            field: 'lastname',
+            type: 'String',
+          },
+          {
+            field: 'fullname',
+            type: 'String',
+            get: (doc) => `${doc.firstname} ${doc.lastname}`,
+          },
+        ],
+      };
+      const projectionBuilder = new ProjectionBuilder(schemaWithSmartFields);
+      const expectedProjection = { $project: { firstname: 1, lastname: 1 } };
+      const actualProjection = projectionBuilder.getProjection(['firstname', 'lastname']);
+
+      expect(actualProjection).toStrictEqual(expectedProjection);
+    });
+  });
+
+  describe('getProjection with requested smart fields', () => {
+    it('should returns null', () => {
+      expect.assertions(1);
+
+      const schemaWithSmartFields = {
+        fields: [
+          {
+            field: 'firstname',
+            type: 'String',
+          },
+          {
+            field: 'lastname',
+            type: 'String',
+          },
+          {
+            field: 'fullname',
+            type: 'String',
+            get: (doc) => `${doc.firstname} ${doc.lastname}`,
+          },
+        ],
+      };
+      const projectionBuilder = new ProjectionBuilder(schemaWithSmartFields);
+      const expectedProjection = null;
+      const actualProjection = projectionBuilder.getProjection(['fullname']);
+
+      expect(actualProjection).toStrictEqual(expectedProjection);
+    });
+  });
+});

--- a/test/tests/services/resources-getter.test.js
+++ b/test/tests/services/resources-getter.test.js
@@ -322,11 +322,11 @@ describe('service > resources-getter', () => {
           timezone: '+01:00',
         };
 
-        const result = await new ResourcesGetter(FilmModel, options, parameters).perform();
-        expect(result[0]).toHaveLength(3);
-        const titles = result[0].filter((film) => !!film.title);
+        const [result] = await new ResourcesGetter(FilmModel, options, parameters).perform();
+        expect(result).toHaveLength(3);
+        const titles = result.filter((film) => !!film.title);
         expect(titles).toHaveLength(3);
-        const durations = result[0].filter((film) => !!film.duration);
+        const durations = result.filter((film) => !!film.duration);
         expect(durations).toHaveLength(3);
       });
     });
@@ -341,11 +341,11 @@ describe('service > resources-getter', () => {
           timezone: '+01:00',
         };
 
-        const result = await new ResourcesGetter(FilmModel, options, parameters).perform();
-        expect(result[0]).toHaveLength(3);
-        const titles = result[0].filter((film) => !!film.title);
+        const [result] = await new ResourcesGetter(FilmModel, options, parameters).perform();
+        expect(result).toHaveLength(3);
+        const titles = result.filter((film) => !!film.title);
         expect(titles).toHaveLength(3);
-        const durations = result[0].filter((film) => !!film.duration);
+        const durations = result.filter((film) => !!film.duration);
         expect(durations).toHaveLength(0);
       });
     });

--- a/test/tests/services/resources-getter.test.js
+++ b/test/tests/services/resources-getter.test.js
@@ -324,9 +324,9 @@ describe('service > resources-getter', () => {
 
         const result = await new ResourcesGetter(FilmModel, options, parameters).perform();
         expect(result[0]).toHaveLength(3);
-        const titles = result[0].filter(film => !!film.title);
+        const titles = result[0].filter((film) => !!film.title);
         expect(titles).toHaveLength(3);
-        const durations = result[0].filter(film => !!film.duration);
+        const durations = result[0].filter((film) => !!film.duration);
         expect(durations).toHaveLength(3);
       });
     });
@@ -343,9 +343,9 @@ describe('service > resources-getter', () => {
 
         const result = await new ResourcesGetter(FilmModel, options, parameters).perform();
         expect(result[0]).toHaveLength(3);
-        const titles = result[0].filter(film => !!film.title);
+        const titles = result[0].filter((film) => !!film.title);
         expect(titles).toHaveLength(3);
-        const durations = result[0].filter(film => !!film.duration);
+        const durations = result[0].filter((film) => !!film.duration);
         expect(durations).toHaveLength(0);
       });
     });


### PR DESCRIPTION
…that are hidden from the UI

Depending on which field is hidden on the UI, field selection is passed to Lumber API (ressources-getter).
Before this PR, mongoose liana returns always all fields from search query.
After this PR, mongoose liana return only fields that are selected, **when there is no smart field in the selected fields selection**


## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
