### PR TITLE
do not returned fields hidden in UI - including smart fields

### DIFF
--- a/src/services/projection-builder.js
+++ b/src/services/projection-builder.js
@@ -17,6 +17,42 @@ class ProjectionBuilder {
     return null;
   }
 
+  static getReferredFields(smartFieldFunction) {
+    const text = smartFieldFunction.toString();
+    // eslint-disable-next-line
+    console.log(text);
+    return null;
+  }
+
+  static getSmartFieldDependancies(schema) {
+    const smartFieldDependancies = {};
+    if (schema && schema.fields) {
+      schema.fields.forEach((field) => {
+        if (field.get) {
+          const referredFields = ProjectionBuilder.getReferredFields(field.get);
+          if (referredFields) {
+            smartFieldDependancies[field.field] = referredFields;
+          }
+        }
+      });
+    }
+    return smartFieldDependancies;
+  }
+
+  expandSmartFields(fieldsNames) {
+    const expandedFields = [];
+    fieldsNames.forEach((field) => {
+      const referencedFields = this.smartFieldMap[field];
+      const fieldIsSmart = !!referencedFields;
+      if (fieldIsSmart) {
+        expandedFields.push(...referencedFields);
+      } else {
+        expandedFields.push(field);
+      }
+    });
+    return expandedFields;
+  }
+
   // NOTICE: Perform the intersection between schema and request smart fields.
   findRequestSmartField(requestFieldsNames) {
     if (this.schemaSmartFields && requestFieldsNames) {

--- a/test/tests/services/projection-builder.test.js
+++ b/test/tests/services/projection-builder.test.js
@@ -1,39 +1,6 @@
 import ProjectionBuilder from '../../../src/services/projection-builder';
 
 describe('service > projection-builder', () => {
-  describe('findRequestSmartField', () => {
-    it('should return the intersect between request fields and schema fields', () => {
-      expect.assertions(1);
-
-      const schemaWithSmartFields = {
-        fields: [
-          {
-            field: 'firstname',
-            type: 'String',
-          },
-          {
-            field: 'lastname',
-            type: 'String',
-          },
-          {
-            field: 'fullname',
-            type: 'String',
-            get: (doc) => `${doc.firstname} ${doc.lastname}`,
-          },
-          {
-            field: 'otherSmartField',
-            type: 'String',
-            get: (doc) => `${doc.firstname} ${doc.lastname}`,
-          },
-        ],
-      };
-      const projectionBuilder = new ProjectionBuilder(schemaWithSmartFields);
-      const requestFields = ['fullname', 'firstname'];
-      const expectedRequestSmartFields = ['fullname'];
-      const actualRequestSmartFields = projectionBuilder.findRequestSmartField(requestFields);
-      expect(actualRequestSmartFields).toStrictEqual(expectedRequestSmartFields);
-    });
-  });
   describe('convertToProjection', () => {
     it('should return a valid projection', () => {
       expect.assertions(1);
@@ -75,7 +42,7 @@ describe('service > projection-builder', () => {
   });
 
   describe('getProjection with requested smart fields', () => {
-    it('should returns null', () => {
+    it('should returns referenced fields in projection', () => {
       expect.assertions(1);
 
       const schemaWithSmartFields = {
@@ -96,10 +63,76 @@ describe('service > projection-builder', () => {
         ],
       };
       const projectionBuilder = new ProjectionBuilder(schemaWithSmartFields);
-      const expectedProjection = null;
+      const expectedProjection = { $project: { firstname: 1, lastname: 1 } };
       const actualProjection = projectionBuilder.getProjection(['fullname']);
 
       expect(actualProjection).toStrictEqual(expectedProjection);
+    });
+  });
+
+  describe('getReferencedFields', () => {
+    it('should returns referenced fields in string concatenation', () => {
+      expect.assertions(1);
+
+      const testedFunction = (doc) => `${doc.firstname} ${doc.lastname}`;
+
+      const actualReferencedFields = ProjectionBuilder.getReferencedFields(testedFunction);
+      const expectedReferencedFields = ['firstname', 'lastname'];
+
+      expect(actualReferencedFields).toStrictEqual(expectedReferencedFields);
+    });
+
+    it('should returns referenced fields in a simple function', () => {
+      expect.assertions(1);
+
+      function testedFunction(doc) {
+        // eslint-disable-next-line
+        return doc.firstname + ' ' + doc.lastname;
+      }
+
+      const actualReferencedFields = ProjectionBuilder.getReferencedFields(testedFunction);
+      const expectedReferencedFields = ['firstname', 'lastname'];
+
+      expect(actualReferencedFields).toStrictEqual(expectedReferencedFields);
+    });
+
+    it('should returns referenced fields in async function', () => {
+      expect.assertions(1);
+
+      /* eslint-disable */
+      async function testedFunction(doc) {
+        return await new Promise((resolve) => {
+          resolve(doc.firstname + ' ' + doc.lastname);
+        });
+      }
+      /* eslint-enable */
+
+      const actualReferencedFields = ProjectionBuilder.getReferencedFields(testedFunction);
+      const expectedReferencedFields = ['firstname', 'lastname'];
+
+      expect(actualReferencedFields).toStrictEqual(expectedReferencedFields);
+    });
+
+    it('should returns referenced fields in spread operator', () => {
+      expect.assertions(1);
+
+      const testedFunction = ({ firstname, lastname }) => `${firstname} ${lastname}`;
+
+      const actualReferencedFields = ProjectionBuilder.getReferencedFields(testedFunction);
+      const expectedReferencedFields = ['firstname', 'lastname'];
+
+      expect(actualReferencedFields).toStrictEqual(expectedReferencedFields);
+    });
+
+    it('should returns referenced fields in spread operator with rest', () => {
+      expect.assertions(1);
+
+      const testedFunction = ({ firstname, ...rest }) => `${firstname} ${rest.lastname}`;
+
+      const actualReferencedFields = ProjectionBuilder.getReferencedFields(testedFunction);
+      const expectedReferencedFields = ['firstname', 'lastname'];
+
+      expect(actualReferencedFields).toStrictEqual(expectedReferencedFields);
     });
   });
 });


### PR DESCRIPTION
This is an experimental PR, please give your opinion.

Problem: Some customers have issues with very big values of fields. They don't want/can't load them in their data view.
Goal: Return **only** fields useful in UI.
Solution: Detect which fields are used inside SmartFields function.