### PR TITLE
[+] Technical - Add sonarJS linter for complexity issues.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,13 +2,19 @@ module.exports = {
   root: true,
   extends: [
     'airbnb-base',
-    'plugin:jest/all'
+    'plugin:jest/all',
+    'plugin:sonarjs/recommended',
   ],
-  plugins: [],
+  plugins: [
+    'sonarjs',
+  ],
   env: {
     node: true,
   },
   rules: {
+    'sonarjs/no-identical-functions': 0,
+    'sonarjs/no-duplicate-string': 0,
+    'sonarjs/no-same-line-conditional': 0,
     'implicit-arrow-linebreak': 0,
     'jest/no-hooks': 0,
     'no-param-reassign': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,8 @@ module.exports = {
     node: true,
   },
   rules: {
+    'sonarjs/cognitive-complexity': 1,
+    'sonarjs/no-duplicated-branches': 1,
     'sonarjs/no-identical-functions': 0,
     'sonarjs/no-duplicate-string': 0,
     'sonarjs/no-same-line-conditional': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,15 +12,7 @@ module.exports = {
     node: true,
   },
   rules: {
-    'sonarjs/cognitive-complexity': 1,
-    'sonarjs/no-duplicated-branches': 1,
-    'sonarjs/no-identical-functions': 0,
-    'sonarjs/no-duplicate-string': 0,
-    'sonarjs/no-same-line-conditional': 0,
     'implicit-arrow-linebreak': 0,
-    'jest/no-hooks': 0,
-    'no-param-reassign': 0,
-    'no-underscore-dangle': 0,
     'import/no-extraneous-dependencies': [
       'error',
       {
@@ -30,6 +22,14 @@ module.exports = {
           'test/**/*.js'
         ]
       }
-    ]
+    ],
+    'jest/no-hooks': 0,
+    'no-param-reassign': 0,
+    'no-underscore-dangle': 0,
+    'sonarjs/cognitive-complexity': 1,
+    'sonarjs/no-duplicate-string': 0,
+    'sonarjs/no-duplicated-branches': 1,
+    'sonarjs/no-identical-functions': 0,
+    'sonarjs/no-same-line-conditional': 0
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Technical - Add SonarJS linter for complexity issues.
+
 ### Changed
 - Performance optimization - In a request with no smart fields, do not return fields that are hidden from the UI.
 - Technical - Upgrade `mongoose` devDependency to the latest version.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "23.0.4",
+    "eslint-plugin-sonarjs": "0.5.0",
     "jest": "24.9.0",
     "mongoose": "5.8.1",
     "mongoose-fixture-loader": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,6 +2146,11 @@ eslint-plugin-jest@23.0.4:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
+eslint-plugin-sonarjs@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.5.0.tgz#ce17b2daba65a874c2862213a9e38e8986ad7d7d"
+  integrity sha512-XW5MnzlRjhXpIdbULC/qAdJYHWw3rRLws/DyawdlPU/IdVr9AmRK1r2LaCvabwKOAW2XYYSo3kDX58E4MrB7PQ==
+
 eslint-scope@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"


### PR DESCRIPTION
This PR installs the sonarJS plugin for eslint.
This PR deactivates all sonarJS rules, except the `sonarjs/cognitive-complexity` rule.

The level is set on `1 / warning` to avoid breaking the build.