### PR TITLE
fix(schema): fix array of enums detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Schema - Fix array of enums detection.
 
 ## RELEASE 6.1.0 - 2020-04-17
 ### Changed

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -148,7 +148,7 @@ module.exports = (model, opts) => {
       //         See: https://mongoosejs.com/docs/schematypes.html#type-key
       if (fieldInfo.options.type[0] instanceof Object
         && fieldInfo.options.type[0].type
-        // NOTICE: In case there is `[{type:{type:String}}]` which means "type" is used as property.
+        // NOTICE: Bypass for schemas like `[{ type: {type: String}, ... }]` where "type" is used as property, and thus we are in the case of an array of embedded documents.
         //         See: https://mongoosejs.com/docs/faq.html#type-key
         && !fieldInfo.options.type[0].type.type) {
         return [getTypeFromNative(fieldInfo.options.type[0])];

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -149,7 +149,7 @@ module.exports = (model, opts) => {
       if (fieldInfo.options.type[0] instanceof Object
         && fieldInfo.options.type[0].type
         // NOTICE: In case there is `[{type:{type:String}}]` which means "type" is used as property.
-        //         See: https://mongoosejs.com/docs/faq.html#type-key).
+        //         See: https://mongoosejs.com/docs/faq.html#type-key
         && !fieldInfo.options.type[0].type.type) {
         return [getTypeFromNative(fieldInfo.options.type[0])];
       }

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -148,7 +148,8 @@ module.exports = (model, opts) => {
       //         See: https://mongoosejs.com/docs/schematypes.html#type-key
       if (fieldInfo.options.type[0] instanceof Object
         && fieldInfo.options.type[0].type
-        // NOTICE: Bypass for schemas like `[{ type: {type: String}, ... }]` where "type" is used as property, and thus we are in the case of an array of embedded documents.
+        // NOTICE: Bypass for schemas like `[{ type: {type: String}, ... }]` where "type" is used
+        //         as property, and thus we are in the case of an array of embedded documents.
         //         See: https://mongoosejs.com/docs/faq.html#type-key
         && !fieldInfo.options.type[0].type.type) {
         return [getTypeFromNative(fieldInfo.options.type[0])];

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -145,7 +145,7 @@ module.exports = (model, opts) => {
       }
 
       // NOTICE: Object with `type` reserved keyword.
-      //         See: https://mongoosejs.com/docs/schematypes.html#type-key).
+      //         See: https://mongoosejs.com/docs/schematypes.html#type-key
       if (fieldInfo.options.type[0] instanceof Object
         && fieldInfo.options.type[0].type
         // NOTICE: In case there is `[{type:{type:String}}]` which means "type" is used as property.

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -144,8 +144,13 @@ module.exports = (model, opts) => {
         return [schemaType(fieldInfo.options.type[0])];
       }
 
-      // NOTICE: Object with `type` property keyword (https://mongoosejs.com/docs/schematypes.html#type-key)
-      if (fieldInfo.options.type[0] instanceof Object && fieldInfo.options.type[0].type) {
+      // NOTICE: Object with `type` reserved keyword.
+      //         See: https://mongoosejs.com/docs/schematypes.html#type-key).
+      if (fieldInfo.options.type[0] instanceof Object
+        && fieldInfo.options.type[0].type
+        // NOTICE: In case there is `[{type:{type:String}}]` which means "type" is used as property.
+        //         See: https://mongoosejs.com/docs/faq.html#type-key).
+        && !fieldInfo.options.type[0].type.type) {
         return [getTypeFromNative(fieldInfo.options.type[0])];
       }
 

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -143,6 +143,12 @@ module.exports = (model, opts) => {
         // Schema
         return [schemaType(fieldInfo.options.type[0])];
       }
+
+      // NOTICE: Object with `type` property keyword (https://mongoosejs.com/docs/schematypes.html#type-key)
+      if (fieldInfo.options.type[0] instanceof Object && fieldInfo.options.type[0].type) {
+        return [getTypeFromNative(fieldInfo.options.type[0])];
+      }
+
       // Object
       return [objectType(fieldInfo.options.type[0], (key) =>
         getTypeFromNative(fieldInfo.options.type[0][key]))];
@@ -250,6 +256,11 @@ module.exports = (model, opts) => {
 
     if (fieldInfo.enumValues && fieldInfo.enumValues.length) {
       schema.enums = fieldInfo.enumValues;
+    }
+
+    // NOTICE: Create enums from caster (for ['Enum'] type).
+    if (fieldInfo.caster && fieldInfo.caster.enumValues && fieldInfo.caster.enumValues.length) {
+      schema.enums = fieldInfo.caster.enumValues;
     }
 
     const isRequired = getRequired(fieldInfo);

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -470,7 +470,6 @@ describe('adapters > schema-adapter', () => {
         mongoose,
         connections: [mongoose],
       });
-      console.log(result.fields);
       expect(result.fields[0].type[0].fields).toStrictEqual([
         { field: 'type', type: 'String' },
         { field: 'value', type: 'String' },

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -278,6 +278,28 @@ describe('adapters > schema-adapter', () => {
     });
   });
 
+  describe('array of string with enum values', () => {
+    it('should have the type [Enum]', async () => {
+      expect.assertions(4);
+      const schema = mongoose.Schema({
+        permissions: [{
+          type: String,
+          enum: ['user:read', 'user:write'],
+        }],
+      });
+      const model = mongoose.model('User', schema);
+
+      const result = await new SchemaAdapter(model, {
+        mongoose,
+        connections: [mongoose],
+      });
+      expect(result).toHaveProperty('fields');
+      expect(result.fields[0]).toHaveProperty('field', 'permissions');
+      expect(result.fields[0]).toHaveProperty('type', ['Enum']);
+      expect(result.fields[0]).toHaveProperty('enums', ['user:read', 'user:write']);
+    });
+  });
+
   describe('array of objectids ([type: ObjectId])', () => {
     it('should have the type [String]', async () => {
       expect.assertions(4);
@@ -438,7 +460,7 @@ describe('adapters > schema-adapter', () => {
       expect.assertions(1);
       const schema = mongoose.Schema({
         action: [{
-          type: String,
+          type: { type: String },
           value: String,
         }],
       });
@@ -448,6 +470,7 @@ describe('adapters > schema-adapter', () => {
         mongoose,
         connections: [mongoose],
       });
+      console.log(result.fields);
       expect(result.fields[0].type[0].fields).toStrictEqual([
         { field: 'type', type: 'String' },
         { field: 'value', type: 'String' },


### PR DESCRIPTION
See: https://github.com/ForestAdmin/forest-express-mongoose/pull/220. Generates this:

```json
{
  "field": "permissions",
  "type": ["Enum"],
  "defaultValue": null,
  "enums": ["user:read", "user:write"],
  "integration": null,
  "isFilterable": true,
  "isReadOnly": false,
  "isRequired": false,
  "isSortable": true,
  "isVirtual": false,
  "reference": null,
  "inverseOf": null,
  "validations": []
}
```

From this: 

```js
new Schema({
  permissions: [{
    type: String,
    enum: [
      "user:read",
      "user:write"
    ],
  }]
}
```

I had to fix a test (see comment below).

I will notify users and add a message in this PR (and the original one) after validation.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code(1)

_(1) The whole `src/adapters/mongoose.js`should be refactored (code is hard to read and understand). Still, we should not mix a difficult refactor task with this simple fix. Anyway, sonarjs [is aware](https://travis-ci.com/github/ForestAdmin/forest-express-mongoose/builds/162429125#L226) of this issue._ 