### PR TITLE
fix(technical): remove MongoClient deprecation warnings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Technical - Remove MongoClient deprecation warnings in tests.
 
 ## RELEASE 6.1.1 - 2020-04-28
 ### Fixed

--- a/test/utils/mongoose-connect.js
+++ b/test/utils/mongoose-connect.js
@@ -5,7 +5,10 @@ mongoose.Promise = P;
 
 function mongooseConnect() {
   return new P((resolve, reject) => {
-    mongoose.connect('mongodb://localhost:27017/forest-test');
+    mongoose.connect(
+      'mongodb://localhost:27017/forest-test',
+      { useNewUrlParser: true, useUnifiedTopology: true },
+    );
 
     const db = mongoose.connection;
     db.on('error', (error) => {


### PR DESCRIPTION
Remove this:

<img width="1012" alt="Capture d’écran 2020-04-28 à 16 41 45" src="https://user-images.githubusercontent.com/1575946/80500967-28f8f180-896f-11ea-9690-bd37a37d31a7.png">

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Write changes made in the CHANGELOG.md
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
