### PR TITLE
ci: force tests to be run sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "build:watch": "onchange 'src/**/*.js' -i -- yarn build",
     "lint": "./node_modules/eslint/bin/eslint.js .eslint-bin scripts src test",
     "readme:update-coverage": "yarn test:coverage && node ./scripts/update-coverage.js",
-    "test": "jest",
-    "test:coverage": "jest --coverage --collectCoverageFrom=\"src/**/*.{ts,js}\""
+    "test": "jest --runInBand",
+    "test:coverage": "jest --runInBand --coverage --collectCoverageFrom=\"src/**/*.{ts,js}\""
   }
 }


### PR DESCRIPTION
When launched locally, tests randomly fail because jest is running them in parallel. 

Some tests are depending on the order they are executed, and different tests are using the same collections.

For instance, the same collection of islands is changed both in tests of the deletion and creation. These tests can interfere with each other.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
