### PR TITLE
feat: extract a isGenerated property for each field, allow to create entry specifying the _id

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "build:watch": "onchange 'src/**/*.js' -i -- yarn build",
     "lint": "./node_modules/eslint/bin/eslint.js .eslint-bin scripts src test",
     "readme:update-coverage": "yarn test:coverage && node ./scripts/update-coverage.js",
-    "test": "jest",
-    "test:coverage": "jest --coverage --collectCoverageFrom=\"src/**/*.{ts,js}\""
+    "test": "jest --runInBand",
+    "test:coverage": "jest --runInBand --coverage --collectCoverageFrom=\"src/**/*.{ts,js}\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "build:watch": "onchange 'src/**/*.js' -i -- yarn build",
     "lint": "./node_modules/eslint/bin/eslint.js .eslint-bin scripts src test",
     "readme:update-coverage": "yarn test:coverage && node ./scripts/update-coverage.js",
-    "test": "jest --runInBand",
-    "test:coverage": "jest --runInBand --coverage --collectCoverageFrom=\"src/**/*.{ts,js}\""
+    "test": "jest",
+    "test:coverage": "jest --coverage --collectCoverageFrom=\"src/**/*.{ts,js}\""
   }
 }

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -200,7 +200,15 @@ module.exports = (model, opts) => {
   });
 
   function getRequired(fieldInfo) {
-    return fieldInfo.isRequired === true;
+    return fieldInfo.isRequired === true || fieldInfo.path === '_id';
+  }
+
+  function getGenerated(fieldInfo) {
+    return Boolean(fieldInfo.options && (fieldInfo.options.auto || fieldInfo.options.default));
+  }
+
+  function getReadOnly(fieldInfo) {
+    return fieldInfo.path === '_id';
   }
 
   function getValidations(fieldInfo) {
@@ -267,6 +275,12 @@ module.exports = (model, opts) => {
     const isRequired = getRequired(fieldInfo);
     if (isRequired) {
       schema.isRequired = isRequired;
+    }
+
+    schema.isGenerated = getGenerated(fieldInfo);
+
+    if (getReadOnly(fieldInfo)) {
+      schema.isReadOnly = true;
     }
 
     if (fieldInfo.options && !_.isNull(fieldInfo.options.default)

--- a/src/services/resource-creator.js
+++ b/src/services/resource-creator.js
@@ -5,10 +5,14 @@ const utils = require('../utils/schema');
 
 function ResourceCreator(Model, params) {
   const schema = Interface.Schemas.schemas[utils.getModelName(Model)];
-
   function create() {
     return new P((resolve, reject) => {
-      if ('_id' in params) { delete params._id; }
+      const idField = schema.fields.find((field) => field.field === '_id');
+      const isAutomaticId = !idField || idField.isGenerated;
+
+      if ('_id' in params && isAutomaticId) {
+        delete params._id;
+      }
 
       new Model(params)
         .save((err, record) => {

--- a/src/services/resource-creator.js
+++ b/src/services/resource-creator.js
@@ -5,6 +5,7 @@ const utils = require('../utils/schema');
 
 function ResourceCreator(Model, params) {
   const schema = Interface.Schemas.schemas[utils.getModelName(Model)];
+
   function create() {
     return new P((resolve, reject) => {
       const idField = schema.fields.find((field) => field.field === '_id');

--- a/src/services/resource-remover.js
+++ b/src/services/resource-remover.js
@@ -3,7 +3,7 @@ const P = require('bluebird');
 function ResourceRemover(Model, params) {
   this.perform = () =>
     new P((resolve, reject) => {
-      Model.remove({ _id: params.recordId }, (err) => {
+      Model.deleteOne({ _id: params.recordId }, (err) => {
         if (err) { return reject(err); }
         return resolve();
       });

--- a/test/tests/adapters/expected-results/deep-nested-object.json
+++ b/test/tests/adapters/expected-results/deep-nested-object.json
@@ -169,11 +169,15 @@
             }
           }
         ]
-      }
+      },
+      "isGenerated": false
     },
     {
       "field": "_id",
-      "type": "String"
+      "type": "String",
+      "isRequired": true,
+      "isReadOnly": true,
+      "isGenerated": true
     }
   ]
 }

--- a/test/tests/adapters/expected-results/deep-nested-schema.json
+++ b/test/tests/adapters/expected-results/deep-nested-schema.json
@@ -7,7 +7,8 @@
       "field": "field1",
       "type": [
         "Date"
-      ]
+      ],
+      "isGenerated": false
     },
     {
       "field": "field2",
@@ -22,7 +23,8 @@
             "type": "Number"
           }
         ]
-      }
+      },
+      "isGenerated": false
     },
     {
       "field": "depth1",
@@ -69,11 +71,15 @@
             ]
           }
         ]
-      }
+      },
+      "isGenerated": false
     },
     {
       "field": "_id",
-      "type": "String"
+      "type": "String",
+      "isRequired": true,
+      "isReadOnly": true,
+      "isGenerated": true
     }
   ]
 }

--- a/test/tests/adapters/expected-results/real-world-schema.json
+++ b/test/tests/adapters/expected-results/real-world-schema.json
@@ -7,6 +7,7 @@
       "field": "name",
       "type": "String",
       "isRequired": true,
+      "isGenerated": false,
       "validations": [
         {
           "type": "is present"
@@ -17,6 +18,7 @@
       "field": "introText",
       "type": "String",
       "isRequired": true,
+      "isGenerated": false,
       "validations": [
         {
           "type": "is present"
@@ -25,12 +27,14 @@
     },
     {
       "field": "outroText",
-      "type": "String"
+      "type": "String",
+      "isGenerated": false
     },
     {
       "field": "pretest",
       "type": "Boolean",
       "isRequired": true,
+      "isGenerated": false,
       "defaultValue": false,
       "validations": [
         {
@@ -42,6 +46,7 @@
       "field": "closeAt",
       "type": "Date",
       "isRequired": true,
+      "isGenerated": true,
       "validations": [
         {
           "type": "is present"
@@ -52,6 +57,7 @@
       "field": "launchAt",
       "type": "Date",
       "isRequired": true,
+      "isGenerated": true,
       "validations": [
         {
           "type": "is present"
@@ -79,6 +85,7 @@
         }
       ],
       "isRequired": true,
+      "isGenerated": true,
       "defaultValue": [],
       "validations": [
         {
@@ -151,6 +158,7 @@
         }
       ],
       "isRequired": true,
+      "isGenerated": true,
       "defaultValue": [],
       "validations": [
         {
@@ -179,6 +187,7 @@
         }
       ],
       "isRequired": true,
+      "isGenerated": true,
       "defaultValue": [],
       "validations": [
         {
@@ -265,6 +274,7 @@
         }
       ],
       "isRequired": true,
+      "isGenerated": true,
       "defaultValue": [],
       "validations": [
         {
@@ -305,6 +315,7 @@
         }
       ],
       "isRequired": true,
+      "isGenerated": true,
       "defaultValue": [],
       "validations": [
         {
@@ -341,6 +352,7 @@
         ]
       },
       "isRequired": true,
+      "isGenerated": true,
       "defaultValue": {
         "attnCheck": true,
         "poststratify": true
@@ -402,6 +414,7 @@
         ]
       },
       "isRequired": true,
+      "isGenerated": true,
       "defaultValue": {
         "country": "US"
       },
@@ -428,11 +441,15 @@
             "type": "Date"
           }
         ]
-      }
+      },
+      "isGenerated": false
     },
     {
       "field": "_id",
-      "type": "String"
+      "type": "String",
+      "isRequired": true,
+      "isGenerated": true,
+      "isReadOnly": true
     }
   ]
 }

--- a/test/tests/services/filters-parser.test.js
+++ b/test/tests/services/filters-parser.test.js
@@ -48,7 +48,7 @@ describe('service > filters-parser', () => {
         IslandModel = mongoose.model('Island', IslandSchema);
 
         defaultParser = new FiltersParser(IslandModel, timezone, options);
-        return IslandModel.remove({});
+        return IslandModel.deleteMany({});
       })
       .then(() =>
         loadFixture(IslandModel, [

--- a/test/tests/services/query-builder.test.js
+++ b/test/tests/services/query-builder.test.js
@@ -60,7 +60,7 @@ describe('service > query-builder', () => {
         LumberJackModel = mongoose.model('LumberJack', LumberJackSchema);
         TreeModel = mongoose.model('Tree', TreeSchema);
 
-        return Promise.all([LumberJackModel.remove({}), TreeModel.remove({})]);
+        return Promise.all([LumberJackModel.deleteMany({}), TreeModel.deleteMany({})]);
       })
       .then(() =>
         Promise.all([

--- a/test/tests/services/resource-remover.test.js
+++ b/test/tests/services/resource-remover.test.js
@@ -29,14 +29,14 @@ describe('service > resource-remover', () => {
         });
 
         IslandModel = mongoose.model('Island', IslandSchema);
-        return IslandModel.remove({});
+        return IslandModel.deleteMany({});
       });
   });
 
   afterAll(() => mongoose.connection.close());
 
   beforeEach(async () => {
-    await IslandModel.remove({});
+    await IslandModel.deleteMany({});
     await loadFixture(IslandModel, [
       { name: 'Kauai', _id: '56cb91bdc3464f14678934ca' },
       { name: 'Oahu', _id: '56cb91bdc3464f14678934cb' },

--- a/test/tests/services/resources-creator.test.js
+++ b/test/tests/services/resources-creator.test.js
@@ -5,71 +5,134 @@ import ResourcesCreator from '../../../src/services/resource-creator';
 import mongooseConnect from '../../utils/mongoose-connect';
 
 describe('service > resources-creator', () => {
-  let IslandModel;
+  describe('> with auto-generated ids', () => {
+    let IslandModel;
 
-  beforeAll(() => {
-    Interface.Schemas = {
-      schemas: {
-        Island: {
-          name: 'Island',
-          idField: '_id',
-          searchFields: ['name'],
-          fields: [
-            { field: '_id', type: 'String' },
-            { field: 'name', type: 'String' },
-            { field: 'population', type: 'Number' },
-          ],
+    beforeAll(() => {
+      Interface.Schemas = {
+        schemas: {
+          Island: {
+            name: 'Island',
+            idField: '_id',
+            searchFields: ['name'],
+            fields: [
+              { field: '_id', type: 'String', isGenerated: true },
+              { field: 'name', type: 'String', isGenerated: false },
+              { field: 'population', type: 'Number', isGenerated: false },
+            ],
+          },
         },
-      },
-    };
+      };
 
-    return mongooseConnect()
-      .then(() => {
-        const IslandSchema = mongoose.Schema({
-          name: {
-            type: String,
-            validate: {
-              validator: (v) => ['Kauai', 'Oahu', 'Haiti'].includes(v),
-              message: (props) => `${props.value} is not valid`,
+      return mongooseConnect()
+        .then(() => {
+          const IslandSchema = mongoose.Schema({
+            name: {
+              type: String,
+              validate: {
+                validator: (v) => ['Kauai', 'Oahu', 'Haiti'].includes(v),
+                message: (props) => `${props.value} is not valid`,
+              },
             },
-          },
-          population: {
-            type: Number,
-          },
+            population: {
+              type: Number,
+            },
+          });
+
+          IslandModel = mongoose.model('Island', IslandSchema);
+          return IslandModel.deleteMany({});
         });
+    });
 
-        IslandModel = mongoose.model('Island', IslandSchema);
-        return IslandModel.deleteMany({});
+    afterAll(() => mongoose.connection.close());
+
+    beforeEach(async () => {
+      await IslandModel.deleteMany({});
+      await loadFixture(IslandModel, [
+        { name: 'Kauai', population: 3, _id: '56cb91bdc3464f14678934ca' },
+        { name: 'Oahu', population: 4, _id: '56cb91bdc3464f14678934cb' },
+      ]);
+    });
+
+    it('should reject with validation error', async () => {
+      expect.assertions(1);
+      await expect(new ResourcesCreator(IslandModel, { name: 'Wrong name' })
+        .perform()).rejects.toThrow(ValidationError);
+    });
+
+    it('should resolve with updated object', async () => {
+      expect.assertions(1);
+      await expect(await new ResourcesCreator(IslandModel, { name: 'Haiti' })
+        .perform()).toHaveProperty('name', 'Haiti');
+    });
+
+    it('should ignore _id with updated object', async () => {
+      expect.assertions(2);
+      const result = await new ResourcesCreator(IslandModel, { _id: '56cb91bdc3464f14678934ca', name: 'Haiti' })
+        .perform();
+      expect(result).toHaveProperty('name', 'Haiti');
+      expect(result.id).not.toBe('56cb91bdc3464f14678934ca');
+    });
+  });
+
+  describe('> with non-auto-generated ids', () => {
+    let model;
+
+    beforeAll(async () => {
+      await mongooseConnect();
+
+      Interface.Schemas = {
+        schemas: {
+          Location: {
+            name: 'Location',
+            idField: '_id',
+            searchFields: ['name'],
+            fields: [
+              { field: '_id', type: 'String', isGenerated: false },
+              { field: 'name', type: 'String', isGenerated: false },
+            ],
+          },
+        },
+      };
+
+      const schema = mongoose.Schema({
+        _id: {
+          type: String,
+        },
+        name: {
+          type: String,
+        },
       });
-  });
 
-  afterAll(() => mongoose.connection.close());
+      model = mongoose.model('Location', schema);
+    });
 
-  beforeEach(async () => {
-    await IslandModel.deleteMany({});
-    await loadFixture(IslandModel, [
-      { name: 'Kauai', population: 3, _id: '56cb91bdc3464f14678934ca' },
-      { name: 'Oahu', population: 4, _id: '56cb91bdc3464f14678934cb' },
-    ]);
-  });
+    afterEach(async () => {
+      await model.deleteMany({});
+    });
 
-  it('should reject with validation error', async () => {
-    expect.assertions(1);
-    await expect(new ResourcesCreator(IslandModel, { name: 'Wrong name' })
-      .perform()).rejects.toThrow(ValidationError);
-  });
+    afterAll(async () => {
+      await mongoose.connection.close();
+    });
 
-  it('should resolve with updated object', async () => {
-    expect.assertions(1);
-    await expect(await new ResourcesCreator(IslandModel, { name: 'Haiti' })
-      .perform()).toHaveProperty('name', 'Haiti');
-  });
+    it('should keep the _id field when creating a document', async () => {
+      expect.assertions(2);
+      const result = await new ResourcesCreator(model, { _id: 'haiti-id', name: 'Haiti' })
+        .perform();
+      expect(result).toHaveProperty('name', 'Haiti');
+      expect(result._id).toBe('haiti-id');
+    });
 
-  it('should ignore _id with updated object', async () => {
-    expect.assertions(2);
-    const result = await new ResourcesCreator(IslandModel, { _id: '56cb91bdc3464f14678934ca', name: 'Haiti' })
-      .perform();
-    expect(result).toHaveProperty('name', 'Haiti');
-    expect(result.id).not.toBe('56cb91bdc3464f14678934ca');
+    it('should throw an exception if the same id is inserted twice', async () => {
+      expect.assertions(1);
+      await model.create({ _id: 'the-id', name: 'some place' });
+
+      await expect(
+        new ResourcesCreator(
+          model,
+          { _id: 'the-id', name: 'another place' },
+        ).perform(),
+      ).rejects.toThrow(/^E11000 duplicate key error collection/);
+    });
   });
 });

--- a/test/tests/services/resources-getter.test.js
+++ b/test/tests/services/resources-getter.test.js
@@ -84,7 +84,11 @@ describe('service > resources-getter', () => {
         UserModel = mongoose.model('User', UserSchema);
         FilmModel = mongoose.model('Film', FilmSchema);
 
-        return Promise.all([OrderModel.remove({}), UserModel.remove({}), FilmModel.remove({})]);
+        return Promise.all([
+          OrderModel.deleteMany({}),
+          UserModel.deleteMany({}),
+          FilmModel.deleteMany({}),
+        ]);
       })
       .then(() =>
         Promise.all([

--- a/test/tests/services/resources-remover.test.js
+++ b/test/tests/services/resources-remover.test.js
@@ -30,14 +30,14 @@ describe('service > resources-remover', () => {
         });
 
         IslandModel = mongoose.model('Island', IslandSchema);
-        return IslandModel.remove({});
+        return IslandModel.deleteMany({});
       });
   });
 
   afterAll(() => mongoose.connection.close());
 
   beforeEach(async () => {
-    await IslandModel.remove({});
+    await IslandModel.deleteMany({});
     await loadFixture(IslandModel, [
       { name: 'Kauai', _id: '56cb91bdc3464f14678934ca' },
       { name: 'Oahu', _id: '56cb91bdc3464f14678934cb' },


### PR DESCRIPTION
Based on #392, for being able to work on the tests.

A new property named `isGenerated` is added to fields' descriptions. It represents the fact that a value will be generated on document creation. When this value will be received as `false` by the frontend (will be done in another PR on the frontend), it will allow to specify a value when creating a document even if the field is read only (otherwise it would be impossible to create documents from the UI).

Linked to CU-48py0a

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
