### PR TITLE
fix: :bug: allow to create documents with non-generated ids

### DIFF
--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -200,7 +200,11 @@ module.exports = (model, opts) => {
   });
 
   function getRequired(fieldInfo) {
-    return fieldInfo.isRequired === true;
+    return fieldInfo.isRequired === true
+      || (
+        fieldInfo.path === '_id'
+        && fieldInfo.options.type !== mongoose.Schema.ObjectId
+      );
   }
 
   function getValidations(fieldInfo) {

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -203,7 +203,7 @@ module.exports = (model, opts) => {
     return fieldInfo.isRequired === true
       || (
         fieldInfo.path === '_id'
-        && fieldInfo.options.type !== mongoose.Schema.ObjectId
+        && !fieldInfo.options.auto
       );
   }
 

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -204,6 +204,7 @@ module.exports = (model, opts) => {
       || (
         fieldInfo.path === '_id'
         && !fieldInfo.options.auto
+        && fieldInfo.options.type !== mongoose.Schema.ObjectId
       );
   }
 

--- a/src/services/resource-creator.js
+++ b/src/services/resource-creator.js
@@ -8,7 +8,12 @@ function ResourceCreator(Model, params) {
 
   function create() {
     return new P((resolve, reject) => {
-      if ('_id' in params) { delete params._id; }
+      const idField = schema.fields.find((field) => field.field === '_id');
+      const isAutomaticId = !idField || !idField.isRequired;
+
+      if ('_id' in params && isAutomaticId) {
+        delete params._id;
+      }
 
       new Model(params)
         .save((err, record) => {

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -693,6 +693,36 @@ describe('adapters > schema-adapter', () => {
       expect(result).toHaveProperty('fields');
       expect(result.fields[0].isRequired).toStrictEqual(true);
     });
+
+    it('should be set to true for non-generated ids', async () => {
+      expect.assertions(2);
+      const schema = mongoose.Schema({
+        _id: String,
+      });
+      const model = mongoose.model('Foo', schema);
+
+      const result = await SchemaAdapter(model, {
+        mongoose,
+        connections: [mongoose],
+      });
+      expect(result).toHaveProperty('fields');
+      expect(result.fields[0].isRequired).toStrictEqual(true);
+    });
+
+    it('should be set to false for non-generated ids', async () => {
+      expect.assertions(2);
+      const schema = mongoose.Schema({
+        _id: mongoose.Schema.ObjectId,
+      });
+      const model = mongoose.model('Foo', schema);
+
+      const result = await SchemaAdapter(model, {
+        mongoose,
+        connections: [mongoose],
+      });
+      expect(result).toHaveProperty('fields');
+      expect(result.fields[0].isRequired).toStrictEqual(false);
+    });
   });
 
   describe('"isRequired" flag', () => {

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -699,7 +699,7 @@ describe('adapters > schema-adapter', () => {
       const schema = mongoose.Schema({
         _id: String,
       });
-      const model = mongoose.model('Foo', schema);
+      const model = mongoose.model('WithNonGeneratedId', schema);
 
       const result = await SchemaAdapter(model, {
         mongoose,
@@ -709,19 +709,19 @@ describe('adapters > schema-adapter', () => {
       expect(result.fields[0].isRequired).toStrictEqual(true);
     });
 
-    it('should be set to false for non-generated ids', async () => {
+    it('should be set to false for generated ids', async () => {
       expect.assertions(2);
       const schema = mongoose.Schema({
         _id: mongoose.Schema.ObjectId,
       });
-      const model = mongoose.model('Foo', schema);
+      const model = mongoose.model('WithGeneratedId', schema);
 
       const result = await SchemaAdapter(model, {
         mongoose,
         connections: [mongoose],
       });
       expect(result).toHaveProperty('fields');
-      expect(result.fields[0].isRequired).toStrictEqual(false);
+      expect(result.fields[0].isRequired).toBeUndefined();
     });
   });
 

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -677,7 +677,7 @@ describe('adapters > schema-adapter', () => {
     });
   });
 
-  describe('isRequired flag', () => {
+  describe('"isRequired" flag', () => {
     it('should be set to true', async () => {
       expect.assertions(2);
       const schema = mongoose.Schema({
@@ -723,9 +723,7 @@ describe('adapters > schema-adapter', () => {
       expect(result).toHaveProperty('fields');
       expect(result.fields[0].isRequired).toBeUndefined();
     });
-  });
 
-  describe('"isRequired" flag', () => {
     it('should not appear', async () => {
       expect.assertions(2);
       const schema = mongoose.Schema({


### PR DESCRIPTION
Linked to CU-48py0a

When a schema is declared like this:

```
const schema = mongoose.Schema({
  '_id': Number,
  'name': String
}, {
  timestamps: false,
});
```

It was not possible to create documents from forestadmin, because the property `_id` was deleted right before creation.

When a property `_id` is not declared as `ObjectId`, mongoose will not automatically generate an id for a new entry. 

That's why, in this case, this property has its value `isRequired=true`. The user has to provide a value, in order for a document to be created. 

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
