### PR TITLE
improvement: identify primary key fields as such

### DIFF
--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -62,8 +62,11 @@ module.exports = (model, opts) => {
       const field = {
         field: fieldName,
         type: getType(fieldName),
-        isPrimaryKey: fieldName === '_id',
       };
+
+      if (fieldName === '_id') {
+        field.isPrimaryKey = true;
+      }
 
       if (!field.type) { return; }
 
@@ -190,8 +193,11 @@ module.exports = (model, opts) => {
       const field = {
         field: fieldName,
         type: getTypeFromMongoose(fieldType),
-        isPrimaryKey: fieldName === '_id',
       };
+
+      if (fieldName === '_id') {
+        field.isPrimaryKey = true;
+      }
 
       if (fieldType.enumValues && fieldType.enumValues.length) {
         field.enums = fieldType.enumValues;
@@ -276,7 +282,9 @@ module.exports = (model, opts) => {
       schema.isRequired = isRequired;
     }
 
-    schema.isPrimaryKey = path === '_id';
+    if (path === '_id') {
+      schema.isPrimaryKey = true;
+    }
 
     if (fieldInfo.options && !_.isNull(fieldInfo.options.default)
       && !_.isUndefined(fieldInfo.options.default)

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -62,6 +62,7 @@ module.exports = (model, opts) => {
       const field = {
         field: fieldName,
         type: getType(fieldName),
+        isPrimaryKey: fieldName === '_id',
       };
 
       if (!field.type) { return; }
@@ -189,6 +190,7 @@ module.exports = (model, opts) => {
       const field = {
         field: fieldName,
         type: getTypeFromMongoose(fieldType),
+        isPrimaryKey: fieldName === '_id',
       };
 
       if (fieldType.enumValues && fieldType.enumValues.length) {
@@ -274,9 +276,7 @@ module.exports = (model, opts) => {
       schema.isRequired = isRequired;
     }
 
-    if (path === '_id') {
-      schema.isPrimaryKey = true;
-    }
+    schema.isPrimaryKey = path === '_id';
 
     if (fieldInfo.options && !_.isNull(fieldInfo.options.default)
       && !_.isUndefined(fieldInfo.options.default)

--- a/src/adapters/mongoose.js
+++ b/src/adapters/mongoose.js
@@ -274,6 +274,10 @@ module.exports = (model, opts) => {
       schema.isRequired = isRequired;
     }
 
+    if (path === '_id') {
+      schema.isPrimaryKey = true;
+    }
+
     if (fieldInfo.options && !_.isNull(fieldInfo.options.default)
       && !_.isUndefined(fieldInfo.options.default)
       && !_.isFunction(fieldInfo.options.default)) {

--- a/test/tests/adapters/expected-results/deep-nested-object.json
+++ b/test/tests/adapters/expected-results/deep-nested-object.json
@@ -5,20 +5,24 @@
   "fields": [
     {
       "field": "depth1",
+      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "field1",
+            "isPrimaryKey": false,
             "type": [
               "Date"
             ]
           },
           {
             "field": "field2",
+            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "field2Field1",
+                  "isPrimaryKey": false,
                   "type": "Boolean"
                 }
               ]
@@ -26,20 +30,24 @@
           },
           {
             "field": "depth2",
+            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "field1",
+                  "isPrimaryKey": false,
                   "type": [
                     "Date"
                   ]
                 },
                 {
                   "field": "field2",
+                  "isPrimaryKey": false,
                   "type": {
                     "fields": [
                       {
                         "field": "field2Field1",
+                        "isPrimaryKey": false,
                         "type": "Boolean"
                       }
                     ]
@@ -47,20 +55,24 @@
                 },
                 {
                   "field": "depth3",
+                  "isPrimaryKey": false,
                   "type": {
                     "fields": [
                       {
                         "field": "field1",
+                        "isPrimaryKey": false,
                         "type": [
                           "Date"
                         ]
                       },
                       {
                         "field": "field2",
+                        "isPrimaryKey": false,
                         "type": {
                           "fields": [
                             {
                               "field": "field2Field1",
+                              "isPrimaryKey": false,
                               "type": "Boolean"
                             }
                           ]
@@ -68,20 +80,24 @@
                       },
                       {
                         "field": "depth4",
+                        "isPrimaryKey": false,
                         "type": {
                           "fields": [
                             {
                               "field": "field1",
+                              "isPrimaryKey": false,
                               "type": [
                                 "Date"
                               ]
                             },
                             {
                               "field": "field2",
+                              "isPrimaryKey": false,
                               "type": {
                                 "fields": [
                                   {
                                     "field": "field2Field1",
+                                    "isPrimaryKey": false,
                                     "type": "Boolean"
                                   }
                                 ]
@@ -89,20 +105,24 @@
                             },
                             {
                               "field": "depth5",
+                              "isPrimaryKey": false,
                               "type": {
                                 "fields": [
                                   {
                                     "field": "field1",
+                                    "isPrimaryKey": false,
                                     "type": [
                                       "Date"
                                     ]
                                   },
                                   {
                                     "field": "field2",
+                                    "isPrimaryKey": false,
                                     "type": {
                                       "fields": [
                                         {
                                           "field": "field2Field1",
+                                          "isPrimaryKey": false,
                                           "type": "Boolean"
                                         }
                                       ]
@@ -110,20 +130,24 @@
                                   },
                                   {
                                     "field": "depth6",
+                                    "isPrimaryKey": false,
                                     "type": {
                                       "fields": [
                                         {
                                           "field": "field1",
+                                          "isPrimaryKey": false,
                                           "type": [
                                             "Date"
                                           ]
                                         },
                                         {
                                           "field": "field2",
+                                          "isPrimaryKey": false,
                                           "type": {
                                             "fields": [
                                               {
                                                 "field": "field2Field1",
+                                                "isPrimaryKey": false,
                                                 "type": "Boolean"
                                               }
                                             ]
@@ -131,20 +155,24 @@
                                         },
                                         {
                                           "field": "depth7",
+                                          "isPrimaryKey": false,
                                           "type": {
                                             "fields": [
                                               {
                                                 "field": "field1",
+                                                "isPrimaryKey": false,
                                                 "type": [
                                                   "Date"
                                                 ]
                                               },
                                               {
                                                 "field": "field2",
+                                                "isPrimaryKey": false,
                                                 "type": {
                                                   "fields": [
                                                     {
                                                       "field": "field2Field1",
+                                                      "isPrimaryKey": false,
                                                       "type": "Boolean"
                                                     }
                                                   ]

--- a/test/tests/adapters/expected-results/deep-nested-object.json
+++ b/test/tests/adapters/expected-results/deep-nested-object.json
@@ -5,24 +5,20 @@
   "fields": [
     {
       "field": "depth1",
-      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "field1",
-            "isPrimaryKey": false,
             "type": [
               "Date"
             ]
           },
           {
             "field": "field2",
-            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "field2Field1",
-                  "isPrimaryKey": false,
                   "type": "Boolean"
                 }
               ]
@@ -30,24 +26,20 @@
           },
           {
             "field": "depth2",
-            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "field1",
-                  "isPrimaryKey": false,
                   "type": [
                     "Date"
                   ]
                 },
                 {
                   "field": "field2",
-                  "isPrimaryKey": false,
                   "type": {
                     "fields": [
                       {
                         "field": "field2Field1",
-                        "isPrimaryKey": false,
                         "type": "Boolean"
                       }
                     ]
@@ -55,24 +47,20 @@
                 },
                 {
                   "field": "depth3",
-                  "isPrimaryKey": false,
                   "type": {
                     "fields": [
                       {
                         "field": "field1",
-                        "isPrimaryKey": false,
                         "type": [
                           "Date"
                         ]
                       },
                       {
                         "field": "field2",
-                        "isPrimaryKey": false,
                         "type": {
                           "fields": [
                             {
                               "field": "field2Field1",
-                              "isPrimaryKey": false,
                               "type": "Boolean"
                             }
                           ]
@@ -80,24 +68,20 @@
                       },
                       {
                         "field": "depth4",
-                        "isPrimaryKey": false,
                         "type": {
                           "fields": [
                             {
                               "field": "field1",
-                              "isPrimaryKey": false,
                               "type": [
                                 "Date"
                               ]
                             },
                             {
                               "field": "field2",
-                              "isPrimaryKey": false,
                               "type": {
                                 "fields": [
                                   {
                                     "field": "field2Field1",
-                                    "isPrimaryKey": false,
                                     "type": "Boolean"
                                   }
                                 ]
@@ -105,24 +89,20 @@
                             },
                             {
                               "field": "depth5",
-                              "isPrimaryKey": false,
                               "type": {
                                 "fields": [
                                   {
                                     "field": "field1",
-                                    "isPrimaryKey": false,
                                     "type": [
                                       "Date"
                                     ]
                                   },
                                   {
                                     "field": "field2",
-                                    "isPrimaryKey": false,
                                     "type": {
                                       "fields": [
                                         {
                                           "field": "field2Field1",
-                                          "isPrimaryKey": false,
                                           "type": "Boolean"
                                         }
                                       ]
@@ -130,24 +110,20 @@
                                   },
                                   {
                                     "field": "depth6",
-                                    "isPrimaryKey": false,
                                     "type": {
                                       "fields": [
                                         {
                                           "field": "field1",
-                                          "isPrimaryKey": false,
                                           "type": [
                                             "Date"
                                           ]
                                         },
                                         {
                                           "field": "field2",
-                                          "isPrimaryKey": false,
                                           "type": {
                                             "fields": [
                                               {
                                                 "field": "field2Field1",
-                                                "isPrimaryKey": false,
                                                 "type": "Boolean"
                                               }
                                             ]
@@ -155,24 +131,20 @@
                                         },
                                         {
                                           "field": "depth7",
-                                          "isPrimaryKey": false,
                                           "type": {
                                             "fields": [
                                               {
                                                 "field": "field1",
-                                                "isPrimaryKey": false,
                                                 "type": [
                                                   "Date"
                                                 ]
                                               },
                                               {
                                                 "field": "field2",
-                                                "isPrimaryKey": false,
                                                 "type": {
                                                   "fields": [
                                                     {
                                                       "field": "field2Field1",
-                                                      "isPrimaryKey": false,
                                                       "type": "Boolean"
                                                     }
                                                   ]

--- a/test/tests/adapters/expected-results/deep-nested-object.json
+++ b/test/tests/adapters/expected-results/deep-nested-object.json
@@ -173,7 +173,8 @@
     },
     {
       "field": "_id",
-      "type": "String"
+      "type": "String",
+      "isPrimaryKey": true
     }
   ]
 }

--- a/test/tests/adapters/expected-results/deep-nested-schema.json
+++ b/test/tests/adapters/expected-results/deep-nested-schema.json
@@ -5,20 +5,24 @@
   "fields": [
     {
       "field": "field1",
+      "isPrimaryKey": false,
       "type": [
         "Date"
       ]
     },
     {
       "field": "field2",
+      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "field2Field1",
+            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "field2Field2",
+            "isPrimaryKey": false,
             "type": "Number"
           }
         ]
@@ -26,20 +30,24 @@
     },
     {
       "field": "depth1",
+      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "depth1Field1",
+            "isPrimaryKey": false,
             "type": [
               "Date"
             ]
           },
           {
             "field": "depth1Field2",
+            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "depth1Field2Field1",
+                  "isPrimaryKey": false,
                   "type": "Boolean"
                 }
               ]
@@ -47,22 +55,26 @@
           },
           {
             "field": "depth2",
+            "isPrimaryKey": false,
             "type": [
               {
                 "fields": [
                   {
                     "field": "depth2Field1",
+                    "isPrimaryKey": false,
                     "type": [
                       "Date"
                     ]
                   },
                   {
                     "field": "depth2Field2.depth2Field2Field1",
-                    "type": "Boolean"
+                    "type": "Boolean",
+                    "isPrimaryKey": false
                   },
                   {
                     "field": "_id",
-                    "type": "String"
+                    "type": "String",
+                    "isPrimaryKey": true
                   }
                 ]
               }

--- a/test/tests/adapters/expected-results/deep-nested-schema.json
+++ b/test/tests/adapters/expected-results/deep-nested-schema.json
@@ -5,24 +5,20 @@
   "fields": [
     {
       "field": "field1",
-      "isPrimaryKey": false,
       "type": [
         "Date"
       ]
     },
     {
       "field": "field2",
-      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "field2Field1",
-            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "field2Field2",
-            "isPrimaryKey": false,
             "type": "Number"
           }
         ]
@@ -30,24 +26,20 @@
     },
     {
       "field": "depth1",
-      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "depth1Field1",
-            "isPrimaryKey": false,
             "type": [
               "Date"
             ]
           },
           {
             "field": "depth1Field2",
-            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "depth1Field2Field1",
-                  "isPrimaryKey": false,
                   "type": "Boolean"
                 }
               ]
@@ -55,21 +47,18 @@
           },
           {
             "field": "depth2",
-            "isPrimaryKey": false,
             "type": [
               {
                 "fields": [
                   {
                     "field": "depth2Field1",
-                    "isPrimaryKey": false,
                     "type": [
                       "Date"
                     ]
                   },
                   {
                     "field": "depth2Field2.depth2Field2Field1",
-                    "type": "Boolean",
-                    "isPrimaryKey": false
+                    "type": "Boolean"
                   },
                   {
                     "field": "_id",

--- a/test/tests/adapters/expected-results/deep-nested-schema.json
+++ b/test/tests/adapters/expected-results/deep-nested-schema.json
@@ -73,7 +73,8 @@
     },
     {
       "field": "_id",
-      "type": "String"
+      "type": "String",
+      "isPrimaryKey": true
     }
   ]
 }

--- a/test/tests/adapters/expected-results/real-world-schema.json
+++ b/test/tests/adapters/expected-results/real-world-schema.json
@@ -7,7 +7,6 @@
       "field": "name",
       "type": "String",
       "isRequired": true,
-      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -18,7 +17,6 @@
       "field": "introText",
       "type": "String",
       "isRequired": true,
-      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -27,14 +25,12 @@
     },
     {
       "field": "outroText",
-      "isPrimaryKey": false,
       "type": "String"
     },
     {
       "field": "pretest",
       "type": "Boolean",
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": false,
       "validations": [
         {
@@ -46,7 +42,6 @@
       "field": "closeAt",
       "type": "Date",
       "isRequired": true,
-      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -57,7 +52,6 @@
       "field": "launchAt",
       "type": "Date",
       "isRequired": true,
-      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -71,12 +65,10 @@
           "fields": [
             {
               "field": "question_id",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "sortOrder",
-              "isPrimaryKey": false,
               "type": "Number"
             },
             {
@@ -88,7 +80,6 @@
         }
       ],
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -103,34 +94,28 @@
           "fields": [
             {
               "field": "content_id",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "placebo",
-              "isPrimaryKey": false,
               "type": "Boolean"
             },
             {
               "field": "attentionCheck",
-              "isPrimaryKey": false,
               "type": {
                 "fields": [
                   {
                     "field": "questionFieldName",
-                    "isPrimaryKey": false,
                     "type": "String"
                   },
                   {
                     "field": "acceptedAnswers",
-                    "isPrimaryKey": false,
                     "type": [
                       "String"
                     ]
                   },
                   {
                     "field": "question_id",
-                    "isPrimaryKey": false,
                     "type": "String"
                   }
                 ]
@@ -138,12 +123,10 @@
             },
             {
               "field": "batchName",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "batchNum",
-              "isPrimaryKey": false,
               "type": "Number"
             },
             {
@@ -152,17 +135,14 @@
                 "fields": [
                   {
                     "field": "responsesNeeded",
-                    "isPrimaryKey": false,
                     "type": "Number"
                   },
                   {
                     "field": "useRandom",
-                    "isPrimaryKey": false,
                     "type": "Boolean"
                   }
                 ]
-              },
-              "isPrimaryKey": false
+              }
             },
             {
               "field": "_id",
@@ -173,7 +153,6 @@
         }
       ],
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -188,12 +167,10 @@
           "fields": [
             {
               "field": "index_id",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "directionDependency",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
@@ -205,7 +182,6 @@
         }
       ],
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -220,34 +196,28 @@
           "fields": [
             {
               "field": "name",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "sortOrder",
-              "isPrimaryKey": false,
               "type": "Number"
             },
             {
               "field": "index_id",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "filters",
-              "isPrimaryKey": false,
               "type": [
                 {
                   "fields": [
                     {
                       "field": "category",
-                      "isPrimaryKey": false,
                       "type": "String"
                     },
                     {
                       "field": "method",
                       "type": "Enum",
-                      "isPrimaryKey": false,
                       "enums": [
                          "number",
                          "percentile",
@@ -257,7 +227,6 @@
                     {
                       "field": "direction",
                       "type": "Enum",
-                      "isPrimaryKey": false,
                       "enums": [
                          "gt",
                          "lt"
@@ -265,12 +234,10 @@
                     },
                     {
                       "field": "limit",
-                      "isPrimaryKey": false,
                       "type": "Number"
                     },
                     {
                       "field": "allowedValues",
-                      "isPrimaryKey": false,
                       "type": [
                         "String"
                       ]
@@ -286,12 +253,10 @@
             },
             {
               "field": "counts",
-              "isPrimaryKey": false,
               "type": null
             },
             {
               "field": "results",
-              "isPrimaryKey": false,
               "type": [
                 "Json"
               ]
@@ -305,7 +270,6 @@
         }
       ],
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -320,27 +284,22 @@
           "fields": [
             {
               "field": "mode",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "acquisitionConfig_id",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "HITTypeId",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "uniqueWorkerQualificationTypeId",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "completionCode",
-              "isPrimaryKey": false,
               "type": "String"
             },
             {
@@ -352,7 +311,6 @@
         }
       ],
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -366,27 +324,22 @@
         "fields": [
           {
             "field": "attnCheck",
-            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "poststratify",
-            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "censusYear",
-            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "allowDuplicatesAcrossBatches",
-            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "customSegments",
-            "isPrimaryKey": false,
             "type": [
               "String"
             ]
@@ -394,7 +347,6 @@
         ]
       },
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": {
         "attnCheck": true,
         "poststratify": true
@@ -411,24 +363,20 @@
         "fields": [
           {
             "field": "country",
-            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "state",
-            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "included",
-                  "isPrimaryKey": false,
                   "type": [
                     "String"
                   ]
                 },
                 {
                   "field": "excluded",
-                  "isPrimaryKey": false,
                   "type": [
                     "String"
                   ]
@@ -443,12 +391,10 @@
           },
           {
             "field": "settings",
-            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "politicalSpectrum",
-                  "isPrimaryKey": false,
                   "type": [
                     "String"
                   ]
@@ -464,7 +410,6 @@
         ]
       },
       "isRequired": true,
-      "isPrimaryKey": false,
       "defaultValue": {
         "country": "US"
       },
@@ -476,22 +421,18 @@
     },
     {
       "field": "analysisMeta",
-      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "branch",
-            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "commit",
-            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "timestamp",
-            "isPrimaryKey": false,
             "type": "Date"
           }
         ]

--- a/test/tests/adapters/expected-results/real-world-schema.json
+++ b/test/tests/adapters/expected-results/real-world-schema.json
@@ -432,7 +432,8 @@
     },
     {
       "field": "_id",
-      "type": "String"
+      "type": "String",
+      "isPrimaryKey": true
     }
   ]
 }

--- a/test/tests/adapters/expected-results/real-world-schema.json
+++ b/test/tests/adapters/expected-results/real-world-schema.json
@@ -7,6 +7,7 @@
       "field": "name",
       "type": "String",
       "isRequired": true,
+      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -17,6 +18,7 @@
       "field": "introText",
       "type": "String",
       "isRequired": true,
+      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -25,12 +27,14 @@
     },
     {
       "field": "outroText",
+      "isPrimaryKey": false,
       "type": "String"
     },
     {
       "field": "pretest",
       "type": "Boolean",
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": false,
       "validations": [
         {
@@ -42,6 +46,7 @@
       "field": "closeAt",
       "type": "Date",
       "isRequired": true,
+      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -52,6 +57,7 @@
       "field": "launchAt",
       "type": "Date",
       "isRequired": true,
+      "isPrimaryKey": false,
       "validations": [
         {
           "type": "is present"
@@ -65,20 +71,24 @@
           "fields": [
             {
               "field": "question_id",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "sortOrder",
+              "isPrimaryKey": false,
               "type": "Number"
             },
             {
               "field": "_id",
+              "isPrimaryKey": true,
               "type": "String"
             }
           ]
         }
       ],
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -93,28 +103,34 @@
           "fields": [
             {
               "field": "content_id",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "placebo",
+              "isPrimaryKey": false,
               "type": "Boolean"
             },
             {
               "field": "attentionCheck",
+              "isPrimaryKey": false,
               "type": {
                 "fields": [
                   {
                     "field": "questionFieldName",
+                    "isPrimaryKey": false,
                     "type": "String"
                   },
                   {
                     "field": "acceptedAnswers",
+                    "isPrimaryKey": false,
                     "type": [
                       "String"
                     ]
                   },
                   {
                     "field": "question_id",
+                    "isPrimaryKey": false,
                     "type": "String"
                   }
                 ]
@@ -122,10 +138,12 @@
             },
             {
               "field": "batchName",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "batchNum",
+              "isPrimaryKey": false,
               "type": "Number"
             },
             {
@@ -134,23 +152,28 @@
                 "fields": [
                   {
                     "field": "responsesNeeded",
+                    "isPrimaryKey": false,
                     "type": "Number"
                   },
                   {
                     "field": "useRandom",
+                    "isPrimaryKey": false,
                     "type": "Boolean"
                   }
                 ]
-              }
+              },
+              "isPrimaryKey": false
             },
             {
               "field": "_id",
+              "isPrimaryKey": true,
               "type": "String"
             }
           ]
         }
       ],
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -165,20 +188,24 @@
           "fields": [
             {
               "field": "index_id",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "directionDependency",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "_id",
+              "isPrimaryKey": true,
               "type": "String"
             }
           ]
         }
       ],
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -193,28 +220,34 @@
           "fields": [
             {
               "field": "name",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "sortOrder",
+              "isPrimaryKey": false,
               "type": "Number"
             },
             {
               "field": "index_id",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "filters",
+              "isPrimaryKey": false,
               "type": [
                 {
                   "fields": [
                     {
                       "field": "category",
+                      "isPrimaryKey": false,
                       "type": "String"
                     },
                     {
                       "field": "method",
                       "type": "Enum",
+                      "isPrimaryKey": false,
                       "enums": [
                          "number",
                          "percentile",
@@ -224,6 +257,7 @@
                     {
                       "field": "direction",
                       "type": "Enum",
+                      "isPrimaryKey": false,
                       "enums": [
                          "gt",
                          "lt"
@@ -231,16 +265,19 @@
                     },
                     {
                       "field": "limit",
+                      "isPrimaryKey": false,
                       "type": "Number"
                     },
                     {
                       "field": "allowedValues",
+                      "isPrimaryKey": false,
                       "type": [
                         "String"
                       ]
                     },
                     {
                       "field": "_id",
+                      "isPrimaryKey": true,
                       "type": "String"
                     }
                   ]
@@ -249,22 +286,26 @@
             },
             {
               "field": "counts",
+              "isPrimaryKey": false,
               "type": null
             },
             {
               "field": "results",
+              "isPrimaryKey": false,
               "type": [
                 "Json"
               ]
             },
             {
               "field": "_id",
+              "isPrimaryKey": true,
               "type": "String"
             }
           ]
         }
       ],
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -279,32 +320,39 @@
           "fields": [
             {
               "field": "mode",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "acquisitionConfig_id",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "HITTypeId",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "uniqueWorkerQualificationTypeId",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "completionCode",
+              "isPrimaryKey": false,
               "type": "String"
             },
             {
               "field": "_id",
+              "isPrimaryKey": true,
               "type": "String"
             }
           ]
         }
       ],
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": [],
       "validations": [
         {
@@ -318,22 +366,27 @@
         "fields": [
           {
             "field": "attnCheck",
+            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "poststratify",
+            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "censusYear",
+            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "allowDuplicatesAcrossBatches",
+            "isPrimaryKey": false,
             "type": "Boolean"
           },
           {
             "field": "customSegments",
+            "isPrimaryKey": false,
             "type": [
               "String"
             ]
@@ -341,6 +394,7 @@
         ]
       },
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": {
         "attnCheck": true,
         "poststratify": true
@@ -357,26 +411,31 @@
         "fields": [
           {
             "field": "country",
+            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "state",
+            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "included",
+                  "isPrimaryKey": false,
                   "type": [
                     "String"
                   ]
                 },
                 {
                   "field": "excluded",
+                  "isPrimaryKey": false,
                   "type": [
                     "String"
                   ]
                 },
                 {
                   "field": "_id",
+                  "isPrimaryKey": true,
                   "type": "String"
                 }
               ]
@@ -384,16 +443,19 @@
           },
           {
             "field": "settings",
+            "isPrimaryKey": false,
             "type": {
               "fields": [
                 {
                   "field": "politicalSpectrum",
+                  "isPrimaryKey": false,
                   "type": [
                     "String"
                   ]
                 },
                 {
                   "field": "_id",
+                  "isPrimaryKey": true,
                   "type": "String"
                 }
               ]
@@ -402,6 +464,7 @@
         ]
       },
       "isRequired": true,
+      "isPrimaryKey": false,
       "defaultValue": {
         "country": "US"
       },
@@ -413,18 +476,22 @@
     },
     {
       "field": "analysisMeta",
+      "isPrimaryKey": false,
       "type": {
         "fields": [
           {
             "field": "branch",
+            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "commit",
+            "isPrimaryKey": false,
             "type": "String"
           },
           {
             "field": "timestamp",
+            "isPrimaryKey": false,
             "type": "Date"
           }
         ]

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -447,10 +447,10 @@ describe('adapters > schema-adapter', () => {
       expect(result.fields[0].type[0]).toHaveProperty('fields');
 
       expect(result.fields[0].type[0].fields).toStrictEqual([
-        { field: 'firstName', type: 'String' },
-        { field: 'lastName', type: 'String' },
-        { field: 'createdAt', type: 'Date' },
-        { field: '_id', type: 'String' },
+        { field: 'firstName', type: 'String', isPrimaryKey: false },
+        { field: 'lastName', type: 'String', isPrimaryKey: false },
+        { field: 'createdAt', type: 'Date', isPrimaryKey: false },
+        { field: '_id', type: 'String', isPrimaryKey: true },
       ]);
     });
   });
@@ -471,8 +471,8 @@ describe('adapters > schema-adapter', () => {
         connections: [mongoose],
       });
       expect(result.fields[0].type[0].fields).toStrictEqual([
-        { field: 'type', type: 'String' },
-        { field: 'value', type: 'String' },
+        { field: 'type', type: 'String', isPrimaryKey: false },
+        { field: 'value', type: 'String', isPrimaryKey: false },
       ]);
     });
   });
@@ -637,6 +637,7 @@ describe('adapters > schema-adapter', () => {
         field: 'bar',
         type: 'String',
         reference: 'User._id',
+        isPrimaryKey: false,
       });
     });
   });

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -771,7 +771,7 @@ describe('adapters > schema-adapter', () => {
     it('should be set to true on field _id', async () => {
       expect.assertions(2);
 
-      const result = await SchemaAdapter(model, {
+      const result = await createSchemaAdapter(model, {
         mongoose,
         connections: [mongoose],
       });

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -447,9 +447,9 @@ describe('adapters > schema-adapter', () => {
       expect(result.fields[0].type[0]).toHaveProperty('fields');
 
       expect(result.fields[0].type[0].fields).toStrictEqual([
-        { field: 'firstName', type: 'String', isPrimaryKey: false },
-        { field: 'lastName', type: 'String', isPrimaryKey: false },
-        { field: 'createdAt', type: 'Date', isPrimaryKey: false },
+        { field: 'firstName', type: 'String' },
+        { field: 'lastName', type: 'String' },
+        { field: 'createdAt', type: 'Date' },
         { field: '_id', type: 'String', isPrimaryKey: true },
       ]);
     });
@@ -471,8 +471,8 @@ describe('adapters > schema-adapter', () => {
         connections: [mongoose],
       });
       expect(result.fields[0].type[0].fields).toStrictEqual([
-        { field: 'type', type: 'String', isPrimaryKey: false },
-        { field: 'value', type: 'String', isPrimaryKey: false },
+        { field: 'type', type: 'String' },
+        { field: 'value', type: 'String' },
       ]);
     });
   });
@@ -637,7 +637,6 @@ describe('adapters > schema-adapter', () => {
         field: 'bar',
         type: 'String',
         reference: 'User._id',
-        isPrimaryKey: false,
       });
     });
   });

--- a/test/tests/adapters/mongoose.test.js
+++ b/test/tests/adapters/mongoose.test.js
@@ -755,4 +755,30 @@ describe('adapters > schema-adapter', () => {
       expect(result.fields).toHaveLength(2);
     });
   });
+
+  describe('isPrimaryKey flag', () => {
+    let model;
+
+    beforeAll(() => {
+      const schema = new mongoose.Schema({
+        _id: mongoose.Schema.ObjectId,
+        bar: String,
+      });
+      model = mongoose.model('Foo', schema);
+    });
+
+    it('should be set to true on field _id', async () => {
+      expect.assertions(2);
+
+      const result = await SchemaAdapter(model, {
+        mongoose,
+        connections: [mongoose],
+      });
+      expect(result).toHaveProperty('fields');
+
+      const idField = result.fields.find((field) => field.field === '_id');
+
+      expect(idField.isPrimaryKey).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Linked to CU-48py0a

The property `isPrimaryKey` is a new one, that will be used on the server-side and on the frontend, to improve the handling of this special kind of fields.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Create automatic tests
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
