### PR TITLE
fix: switched moment to moment-tz for line-stat-getter

### DIFF
--- a/src/services/line-stat-getter.js
+++ b/src/services/line-stat-getter.js
@@ -1,10 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import _ from 'lodash';
 import P from 'bluebird';
-import moment from 'moment';
-// NOTICE: moment-timezone extends moment itself,
-//         Importing it will automatically add functions to moment.
-import 'moment-timezone';
+import moment from 'moment-timezone';
 import Interface from 'forest-express';
 import QueryBuilder from './query-builder';
 import utils from '../utils/schema';


### PR DESCRIPTION
(https://community.forestadmin.com/t/time-based-charts/1177/23)

Contribution made with a lot of help to find the issue from the support. A lot of things happened on this link, the main one being the fact that `moment-timezone` seems to override `moment` function, but also import it himself.

EDIT: We could do the complete switch to `moment-timezone` since it looks like it work as expected. I would more completely remove `moment-tz` and  in that case TBH, this was mainly done to fix the original issue
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
