### PR TITLE
fix(filters): ensure 'is present' behaves as in forest-express-sequelize

### DIFF
--- a/src/services/filters-parser.js
+++ b/src/services/filters-parser.js
@@ -135,7 +135,7 @@ function FiltersParser(model, timezone, options) {
       case 'not_contains':
         return { $not: new RegExp(`.*${parseFct(value)}.*`) };
       case 'present':
-        return { $exists: true };
+        return { $exists: true, $ne: null };
       case 'blank':
         return { $in: [null, ''] };
       case 'equal':

--- a/test/tests/services/filters-parser.test.js
+++ b/test/tests/services/filters-parser.test.js
@@ -168,7 +168,7 @@ describe('service > filters-parser', () => {
           expect(await defaultParser.formatOperatorValue('name', 'after', value)).toStrictEqual({ $gt: value });
           expect(await defaultParser.formatOperatorValue('name', 'not_contains', value)).toStrictEqual({ $not: new RegExp(`.*${value}.*`) });
           expect(await defaultParser.formatOperatorValue('name', 'not_equal', value)).toStrictEqual({ $ne: value });
-          expect(await defaultParser.formatOperatorValue('name', 'present', value)).toStrictEqual({ $exists: true });
+          expect(await defaultParser.formatOperatorValue('name', 'present', value)).toStrictEqual({ $exists: true, $ne: null });
           expect(await defaultParser.formatOperatorValue('name', 'equal', value)).toStrictEqual(value);
           expect(await defaultParser.formatOperatorValue('name', 'blank', value)).toStrictEqual({ $in: [null, ''] });
         });


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
