### PR TITLE
chore(workflows): bump setup-node and fix node version used in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.17.6
+          node-version: 12.13.0
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
@@ -42,8 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
-        with:
-          node-version: 14.17.6
       - name: Cache node_modules
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
### Description
> is blocking https://github.com/ForestAdmin/forest-express-mongoose/pull/721

Bump trusted external action from v1 to v2 (actions/setup-node)
Fix minimal node version to 14 (the one already used in the lint step)