### PR TITLE
fix: filters on nested fields now works correctly

### DIFF
--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -13,3 +13,29 @@ exports.getModelName = (model) => model.modelName;
 
 // TODO: Remove nameOld attribute once the lianas versions older than 2.0.0 are minority
 exports.getModelNameOld = (model) => model.collection.name.replace(' ', '');
+
+const getNestedFieldType = (mongooseSchema, nestedFieldPath) => {
+  if (!mongooseSchema || !nestedFieldPath) return undefined;
+
+  const [currentFieldName, ...deepNestedFieldPath] = nestedFieldPath.split('.');
+
+  let nestedFieldDeclaration;
+
+  if (mongooseSchema.tree) {
+    nestedFieldDeclaration = mongooseSchema.tree[currentFieldName];
+  } else if (mongooseSchema.type) {
+    nestedFieldDeclaration = mongooseSchema.type[currentFieldName];
+  } else {
+    nestedFieldDeclaration = mongooseSchema[currentFieldName];
+  }
+
+  if (!nestedFieldDeclaration) return undefined;
+
+  if (!deepNestedFieldPath.length) {
+    return nestedFieldDeclaration.type || nestedFieldDeclaration;
+  }
+
+  return getNestedFieldType(nestedFieldDeclaration, deepNestedFieldPath?.join('.'));
+};
+
+exports.getNestedFieldType = getNestedFieldType;

--- a/test/tests/utils/schema.test.js
+++ b/test/tests/utils/schema.test.js
@@ -40,6 +40,8 @@ describe('schema', () => {
     })).schema;
   });
 
+  afterAll(() => mongoose.connection.close());
+
   describe('when the nested field is from a subSchema', () => {
     describe('when the nested field is defined using a type', () => {
       it('should correctly detect the type', () => {

--- a/test/tests/utils/schema.test.js
+++ b/test/tests/utils/schema.test.js
@@ -1,0 +1,128 @@
+import mongoose from 'mongoose';
+import mongooseConnect from '../../utils/mongoose-connect';
+import { getNestedFieldType } from '../../../src/utils/schema';
+
+describe('schema', () => {
+  let nestedModelSchema;
+
+  beforeAll(async () => {
+    await mongooseConnect();
+
+    nestedModelSchema = mongoose.model('cars', new mongoose.Schema({
+      engineSubSchemaAndType: new mongoose.Schema({
+        horsePower: { type: String },
+        _id: { type: mongoose.Schema.Types.ObjectId },
+      }),
+      engineSubSchema: new mongoose.Schema({
+        horsePower: String,
+        _id: mongoose.Schema.Types.ObjectId,
+      }),
+      engineNestedDocumentAndType: {
+        type: {
+          horsePower: { type: String },
+          _id: { type: mongoose.Schema.Types.ObjectId },
+        },
+      },
+      engineNestedDocument: {
+        type: {
+          horsePower: String,
+          _id: mongoose.Schema.Types.ObjectId,
+        },
+      },
+      engineNestedPathAndType: {
+        horsePower: { type: String },
+        _id: { type: mongoose.Schema.Types.ObjectId },
+      },
+      engineNestedPath: {
+        horsePower: String,
+        _id: mongoose.Schema.Types.ObjectId,
+      },
+    })).schema;
+  });
+
+  describe('when the nested field is from a subSchema', () => {
+    describe('when the nested field is defined using a type', () => {
+      it('should correctly detect the type', () => {
+        expect.assertions(2);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineSubSchemaAndType._id'),
+        ).toStrictEqual(mongoose.Schema.Types.ObjectId);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineSubSchemaAndType.horsePower'),
+        ).toStrictEqual(String);
+      });
+    });
+    describe('when the nested field is not defined using a type', () => {
+      it('should correctly detect the type', () => {
+        expect.assertions(2);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineSubSchema._id'),
+        ).toStrictEqual(mongoose.Schema.Types.ObjectId);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineSubSchema.horsePower'),
+        ).toStrictEqual(String);
+      });
+    });
+  });
+
+  describe('when the nested field is from a nested document', () => {
+    describe('when the nested field is defined using a type', () => {
+      it('should correctly detect the type', () => {
+        expect.assertions(2);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedDocumentAndType._id'),
+        ).toStrictEqual(mongoose.Schema.Types.ObjectId);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedDocumentAndType.horsePower'),
+        ).toStrictEqual(String);
+      });
+    });
+    describe('when the nested field is not defined using a type', () => {
+      it('should correctly detect the type', () => {
+        expect.assertions(2);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedDocument._id'),
+        ).toStrictEqual(mongoose.Schema.Types.ObjectId);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedDocument.horsePower'),
+        ).toStrictEqual(String);
+      });
+    });
+  });
+
+
+  describe('when the nested field is from a nested path', () => {
+    describe('when the nested field is defined using a type', () => {
+      it('should correctly detect the type', () => {
+        expect.assertions(2);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedPathAndType._id'),
+        ).toStrictEqual(mongoose.Schema.Types.ObjectId);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedPathAndType.horsePower'),
+        ).toStrictEqual(String);
+      });
+    });
+    describe('when the nested field is not defined using a type', () => {
+      it('should correctly detect the type', () => {
+        expect.assertions(2);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedPath._id'),
+        ).toStrictEqual(mongoose.Schema.Types.ObjectId);
+        expect(
+          getNestedFieldType(nestedModelSchema, 'engineNestedPath.horsePower'),
+        ).toStrictEqual(String);
+      });
+    });
+  });
+
+  describe('when the nested field is not found', () => {
+    it('should return undefined', () => {
+      expect.assertions(1);
+
+      expect(
+        getNestedFieldType(nestedModelSchema, 'engineNestedPath.notExisting'),
+      ).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [x] Ensure that Types have been updated according to your changes (if needed)

### Security

- [x] Consider the security impact of the changes made

⚠️ This is a fix proposal which impacts the filtering system for both nested fields and top level fields ⚠️ 

## The issue 
The issue comes from the fact that, depending how you define your nested field, `model.schema.paths[pathToNestedField]` might not work. You can define your nested fields using the following three solutions: 

1 - **Sub Document with nested schema**:
```
mongoose.Schema({
  'engine': mongoose.Schema({
    'horsePower': String,
  }),
})
```

2 - **Sub Document with type declaration**:
```
mongoose.schema({
  'engine': {
    type: {
      'horsePower': String,
    }
  }
})
```

3 - **Sub Document with nested Path**:
```
mongoose.Schema({
  'engine': {
    'horsePower': String,
  }
})
```

💥 For the above three solutions, only the **solution 3** will make access to nested fields trough `model.schema.paths[pathToNestedField]` possible. That's why we need to change the way we retrieve nested fields. 

## Solution
Correctly introspect the nested fields to retrieve its declared type, and select the correct parser based on all the possible types. 