### PR TITLE
fix: incorrect mongoose type used for ConnectOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import { Application, NextFunction, Request, RequestHandler, Response } from 'express';
 import {
-  ConnectionOptions,
+  ConnectOptions,
   Mongoose,
   Connection,
   Model,
@@ -29,7 +29,7 @@ export interface DatabaseConfiguration {
   modelsDir: string,
   connection: {
     url: string,
-    options: ConnectionOptions,
+    options: ConnectOptions,
   }
 }
 


### PR DESCRIPTION
## Definition of Done
Building forest-admin projects with typescript should not fail. 
Error: `'"mongoose"' has no exported member named 'ConnectionOptions'. Did you mean 'ConnectOptions'?`

### General
This is a typing issue I detected when using typescript in our builds. Mongoose does not export type`ConnectionOptions`. It should be `ConnectOptions`.

### Security
No impact

PS: Adding `"skipLibCheck": true` in our `tsconfig` works as a temporary workaround.