### PR TITLE
chore(deps): bump forest-express to 10.7.0 [force release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babel/runtime": "7.15.4",
     "bluebird": "2.9.25",
-    "forest-express": "10.6.8",
+    "forest-express": "10.7.0",
     "http-errors": "1.7.2",
     "lodash": "4.17.21",
     "moment": "2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4869,10 +4869,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-forest-express@10.6.8:
-  version "10.6.8"
-  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.6.8.tgz#725bb6c87dc9ef38986eaf6deb013391c6ced463"
-  integrity sha512-ZRQKN3v3e5PJUYRTWItJ2jLe4tzfeYAadv1YjnjF8DQSxUQgk3JcpoPupuijmZRjV3NhsaVY1AJr7jnOyBacsA==
+forest-express@10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.7.0.tgz#4eeb5043f8beca10a2141718e64b668c76fc7409"
+  integrity sha512-5/c9Rdu4GNZhTz8vJ/wBt58vMhHIDbfPRCYnPk6Y1Oq/Vug8faGZUMoBbaLY9oX35zHGl+vOlmag7MxDutTtIA==
   dependencies:
     "@babel/runtime" "7.19.0"
     "@forestadmin/context" "1.42.11"


### PR DESCRIPTION
## What
Bumps `forest-express` `10.6.8` → `10.7.0`.

## Why
Brings into forest-express-mongoose the two recent forest-express releases:
- **10.7.0** — `feat(agent): add workflow executor proxy routes` (#1058, PRD-227)
- **10.6.9** — `fix(composite-pk): normalize fields[] query param to comma-separated string` (#1059, PRD-462)

Minor/additive — no breaking change.

## Verification
- `yarn.lock` diff is scoped to the `forest-express` entry only (no transitive changes).
- `yarn lint` clean, **240/240 tests** green — validated on both Node 22.12 and 24.10.

`[force release]` in the subject to publish a patch (a plain `chore` doesn't trigger semantic-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `forest-express` dependency from 10.6.8 to 10.7.0
> Updates the `forest-express` version in [package.json](https://github.com/ForestAdmin/forest-express-mongoose/pull/1127/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and regenerates the lockfile to reflect the new version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8510aa8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->